### PR TITLE
Table names should get canonical name for prefixed tables

### DIFF
--- a/src/Login/Setup/UpgradeSchema.php
+++ b/src/Login/Setup/UpgradeSchema.php
@@ -27,10 +27,10 @@ class UpgradeSchema implements UpgradeSchemaInterface
     {
         if (version_compare($context->getVersion(), '1.1.0', '<')) {
             $setup->getConnection()->addForeignKey(
-                $setup->getFkName(CustomerLink::TABLE_NAME, 'customer_id', 'customer_entity', 'entity_id'),
+                $setup->getFkName(CustomerLink::TABLE_NAME, 'customer_id', $setup->getTable('customer_entity'), 'entity_id'),
                 $setup->getTable(CustomerLink::TABLE_NAME),
                 'customer_id',
-                'customer_entity',
+                $setup->getTable('customer_entity'),
                 'entity_id',
                 AdapterInterface::FK_ACTION_CASCADE
             );

--- a/src/Payment/Api/AddressManagementInterface.php
+++ b/src/Payment/Api/AddressManagementInterface.php
@@ -21,7 +21,7 @@ interface AddressManagementInterface
      * @param string $amazonOrderReferenceId
      * @param string $addressConsentToken
      *
-     * @return array
+     * @return mixed
      */
     public function getShippingAddress($amazonOrderReferenceId, $addressConsentToken);
 
@@ -29,7 +29,7 @@ interface AddressManagementInterface
      * @param string $amazonOrderReferenceId
      * @param string $addressConsentToken
      *
-     * @return array
+     * @return mixed
      */
     public function getBillingAddress($amazonOrderReferenceId, $addressConsentToken);
 }

--- a/src/Payment/Setup/UpgradeSchema.php
+++ b/src/Payment/Setup/UpgradeSchema.php
@@ -174,19 +174,19 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
         if (version_compare($context->getVersion(), '1.6.0', '<')) {
             $setup->getConnection()->addForeignKey(
-                $setup->getFkName(QuoteLink::TABLE_NAME, 'quote_id', 'quote', 'entity_id'),
+                $setup->getFkName(QuoteLink::TABLE_NAME, 'quote_id', $setup->getTable('quote'), 'entity_id'),
                 $setup->getTable(QuoteLink::TABLE_NAME),
                 'quote_id',
-                'quote',
+                $setup->getTable('quote'),
                 'entity_id',
                 AdapterInterface::FK_ACTION_CASCADE
             );
 
             $setup->getConnection()->addForeignKey(
-                $setup->getFkName(OrderLink::TABLE_NAME, 'order_id', 'sales_order', 'entity_id'),
+                $setup->getFkName(OrderLink::TABLE_NAME, 'order_id', $setup->getTable('sales_order'), 'entity_id'),
                 $setup->getTable(OrderLink::TABLE_NAME),
                 'order_id',
-                'sales_order',
+                $setup->getTable('sales_order'),
                 'entity_id',
                 AdapterInterface::FK_ACTION_CASCADE
             );


### PR DESCRIPTION
This prevents an install error when table prefixes are used