### PR TITLE
Integrate checkout agreements

### DIFF
--- a/src/Payment/view/frontend/requirejs-config.js
+++ b/src/Payment/view/frontend/requirejs-config.js
@@ -25,5 +25,12 @@ var config = {
             //this is a fix for Magento 2.1 (ajax / validation fails on add to cart)
             catalogAddToCart: 'Amazon_Payment/js/catalog-add-to-cart'
         }
+    },
+    config: {
+        mixins: {
+            'Amazon_Payment/js/action/place-order': {
+                'Amazon_Payment/js/model/place-order-mixin': true
+            }
+        }
     }
 };

--- a/src/Payment/view/frontend/web/js/model/place-order-mixin.js
+++ b/src/Payment/view/frontend/web/js/model/place-order-mixin.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright © 2016 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+/*jshint browser:true jquery:true*/
+/*global alert*/
+define([
+    'jquery',
+    'mage/utils/wrapper',
+    'Magento_CheckoutAgreements/js/model/agreements-assigner'
+], function ($, wrapper, agreementsAssigner) {
+    'use strict';
+
+    return function (placeOrderAction) {
+
+        /** Override default place order action and add agreement_ids to request */
+        return wrapper.wrap(placeOrderAction, function (originalAction, paymentData, redirectOnSuccess, messageContainer) {
+            agreementsAssigner(paymentData);
+
+            return originalAction(paymentData, redirectOnSuccess, messageContainer);
+        });
+    };
+});

--- a/src/Payment/view/frontend/web/js/model/place-order-mixin.js
+++ b/src/Payment/view/frontend/web/js/model/place-order-mixin.js
@@ -1,6 +1,16 @@
 /**
- * Copyright © 2016 Magento. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
  */
 /*jshint browser:true jquery:true*/
 /*global alert*/

--- a/src/Payment/view/frontend/web/template/payment/amazon-payment-widget.html
+++ b/src/Payment/view/frontend/web/template/payment/amazon-payment-widget.html
@@ -27,12 +27,18 @@
                 <label data-bind="attr: {'for': getCode()}" class="label"><span data-bind="text: getTitle()"></span></label>
             </div>
             <div class="payment-method-content">
-
+                <!-- ko foreach: getRegion('messages') -->
+                <!-- ko template: getTemplate() --><!-- /ko -->
+                <!--/ko-->
                 <div class="amazon-widget-container">
                     <div id="walletWidgetDiv" class="amazon-widget amazon-widget--payment" data-bind="afterRender: initPaymentWidget"></div>
                 </div>
 
-                <div class="checkout-agreements-block"></div>
+                <div class="checkout-agreements-block">
+                    <!-- ko foreach: $parent.getRegion('before-place-order') -->
+                    <!-- ko template: getTemplate() --><!-- /ko -->
+                    <!--/ko-->
+                </div>
 
                 <div class="actions-toolbar">
                     <div class="primary">


### PR DESCRIPTION
The Amazon module was not properly tracking Terms agreements when placing the order.

Initially, the HTML template was missing the code to even render the Messages and Checkout Agreements blocks, so I added it back into the template.

However, this did not solve the problem as it now complained about not accepting the agreement even with the checkbox checked.

I created a new mixin for the place-order JavaScript action based on the one added by the Magento_CheckoutAgreements module that correctly injects the agreement selection into the payment data before submitting to the API.

This allows the order to succeed.