### PR TITLE
Fix potential data issues in CompleteOrderStatus observer

### DIFF
--- a/src/Payment/Observer/CompleteOrderStatus.php
+++ b/src/Payment/Observer/CompleteOrderStatus.php
@@ -19,27 +19,19 @@ use Amazon\Core\Helper\Data;
 use Amazon\Payment\Model\Method\Amazon;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Magento\Quote\Api\PaymentMethodManagementInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order;
 
 class CompleteOrderStatus implements ObserverInterface
 {
     /**
-     * @var PaymentMethodManagementInterface
-     */
-    protected $paymentMethodManagement;
-
-    /**
      * @var Data
      */
     protected $coreHelper;
 
     public function __construct(
-        PaymentMethodManagementInterface $paymentMethodManagement,
         Data $coreHelper
     ) {
-        $this->paymentMethodManagement = $paymentMethodManagement;
         $this->coreHelper              = $coreHelper;
     }
 
@@ -49,7 +41,7 @@ class CompleteOrderStatus implements ObserverInterface
          * @var OrderInterface $order
          */
         $order          = $observer->getOrder();
-        $payment        = $this->paymentMethodManagement->get($order->getQuoteId());
+        $payment        = $order->getPayment();
         $newOrderStatus = $this->coreHelper->getNewOrderStatus();
 
         if ($newOrderStatus


### PR DESCRIPTION
On our server, we have seen certain circumstances where the source quote for an order was no longer available. Because this observer code tries to get the payment method from the quote rather than the order itself, it was causing a fatal error when the quote couldn't be loaded.

By using the payment method defined on the order itself, we should avoid this problem.