### PR TITLE
added scope parameter to payment widgets

### DIFF
--- a/src/Payment/view/frontend/web/js/view/checkout-widget-address.js
+++ b/src/Payment/view/frontend/web/js/view/checkout-widget-address.js
@@ -48,7 +48,8 @@ define(
             },
             options: {
                 sellerId: window.amazonPayment.merchantId,
-                addressWidgetDOMId: 'addressBookWidgetDiv'
+                addressWidgetDOMId: 'addressBookWidgetDiv',
+                widgetScope: window.amazonPayment.loginScope
             },
             isCustomerLoggedIn: customer.isLoggedIn,
             isAmazonAccountLoggedIn: amazonStorage.isAmazonAccountLoggedIn,
@@ -70,6 +71,7 @@ define(
             renderAddressWidget: function () {
                 new OffAmazonPayments.Widgets.AddressBook({
                     sellerId: self.options.sellerId,
+                    scope: self.options.widgetScope,
                     onOrderReferenceCreate: function (orderReference) {
                         var orderid = orderReference.getAmazonOrderReferenceId();
                         amazonStorage.setOrderReference(orderid);

--- a/src/Payment/view/frontend/web/js/view/payment/method-renderer/amazon-payment-widget.js
+++ b/src/Payment/view/frontend/web/js/view/payment/method-renderer/amazon-payment-widget.js
@@ -49,7 +49,8 @@ define(
 
             options: {
                 sellerId: window.amazonPayment.merchantId,
-                paymentWidgetDOMId: 'walletWidgetDiv'
+                paymentWidgetDOMId: 'walletWidgetDiv',
+                widgetScope: window.amazonPayment.loginScope
             },
             isCustomerLoggedIn: customer.isLoggedIn,
             isAmazonAccountLoggedIn: amazonStorage.isAmazonAccountLoggedIn,
@@ -74,6 +75,7 @@ define(
             renderPaymentWidget: function () {
                 new OffAmazonPayments.Widgets.Wallet({
                     sellerId: self.options.sellerId,
+                    scope: self.options.widgetScope,
                     amazonOrderReferenceId: amazonStorage.getOrderReference(),
                     onPaymentSelect: function (orderReference) {
                         amazonStorage.isPlaceOrderDisabled(true);


### PR DESCRIPTION
Since a few weeks, the widgets expect (optionally) the scope used at the button level.