### PR TITLE
Adjusted amazon-core require deps

### DIFF
--- a/src/Payment/view/frontend/web/js/amazon-core.js
+++ b/src/Payment/view/frontend/web/js/amazon-core.js
@@ -18,7 +18,8 @@ define([
     'ko',
     'amazonPaymentConfig',
     'amazonWidgetsLoader',
-    'bluebird'
+    'bluebird',
+    'jquery/jquery-storageapi'
 ], function ($, ko, amazonPaymentConfig) {
     "use strict";
 


### PR DESCRIPTION
By adding jquery/jquery-storageapi as a require dependency $.cookieStorage is always available. In some instances it is not available, depending on what scripts are used in any given instance.

This is a standard dependency to have when using $.cookieStorage. Searching for $.cookieStorage  in the core codebase shows any time it is in use jquery/jquery-storageapi is a dependency.