### PR TITLE
Fix conversion issue applying address

### DIFF
--- a/src/Payment/view/frontend/web/js/view/checkout-widget-address.js
+++ b/src/Payment/view/frontend/web/js/view/checkout-widget-address.js
@@ -114,8 +114,7 @@ define(
                                 addressData.street[i] = '';
                             }
                         }
-                        checkoutData.setShippingAddressFromData(addressConverter.quoteAddressToFormAddressData(addressData));
-                        checkoutDataResolver.resolveShippingAddress();
+                        selectShippingAddress(addressData);
                     }
                 ).fail(
                     function (response) {


### PR DESCRIPTION
There seems to be an issue introduced with Magento 2.1.6 when selecting the address via Amazon.

I'd probably have to diff the Magento code to identify what changed to break it, but essentially the address data is not being captured properly. The region information is not converted properly between the checkout and quote datasets. This causes the shipping method AJAX to fail, causing an endless load.

However, by bypassing the conversion process and using the selectShippingAddress function to directly apply the new address to the quote, the address data is saved correctly allowing the shipping methods to update.