### PR TITLE
AMAZON-38: Forces extension to explicitly use built in modernizr plugin

### DIFF
--- a/src/Payment/view/frontend/web/js/amazon-button.js
+++ b/src/Payment/view/frontend/web/js/amazon-button.js
@@ -21,7 +21,7 @@ define([
     'modernizr/modernizr',
     'amazonCore',
     'jquery/ui'
-], function ($, customerData, sectionConfig, amazonPaymentConfig, amazonCsrf) {
+], function ($, customerData, sectionConfig, amazonPaymentConfig, amazonCsrf, mdrnzr) {
     "use strict";
 
     var _this,
@@ -79,7 +79,7 @@ define([
         },
         usePopUp: function () {
             //always use redirect journey on product page and touch devices
-            return ((window.location.protocol === 'https:' && !$('body').hasClass('catalog-product-view')) && !Modernizr.touch);
+            return ((window.location.protocol === 'https:' && !$('body').hasClass('catalog-product-view')) && !mdrnzr.touch);
         },
         /**
          * onAmazonPaymentsReady

--- a/src/Payment/view/frontend/web/js/amazon-button.js
+++ b/src/Payment/view/frontend/web/js/amazon-button.js
@@ -21,7 +21,7 @@ define([
     'modernizr/modernizr',
     'amazonCore',
     'jquery/ui'
-], function ($, customerData, sectionConfig, amazonPaymentConfig, amazonCsrf, mdrnzr) {
+], function ($, customerData, sectionConfig, amazonPaymentConfig, amazonCsrf) {
     "use strict";
 
     var _this,
@@ -77,9 +77,18 @@ define([
         _popupCallback: function () {
             return _this.usePopUp() ? _this.secureHttpsCallback : amazonPaymentConfig.getValue('oAuthHashRedirectUrl');
         },
+        /**
+         * Are touch events available
+         * (Supports both v2 and v3 Modernizr)
+         * @returns {Boolean}
+         * @private
+         */
+        _touchSupported: function () {
+            return Modernizr.touch !== undefined ? Modernizr.touch : Modernizr.touchevents;
+        },
         usePopUp: function () {
             //always use redirect journey on product page and touch devices
-            return ((window.location.protocol === 'https:' && !$('body').hasClass('catalog-product-view')) && !mdrnzr.touch);
+            return ((window.location.protocol === 'https:' && !$('body').hasClass('catalog-product-view')) && !_this._touchSupported());
         },
         /**
          * onAmazonPaymentsReady


### PR DESCRIPTION
This update forces extension to explicitly use Magento 2 built in Modernizr plugin. Previously it used global object declaration to call it potentially causing problems when a newer, but backward incompatible Modernizr 3.x plugin was also available in addition to built-in 2.x.