### PR TITLE
Changed the way how 'amazon_payment' is retrieved

### DIFF
--- a/src/Payment/view/frontend/web/js/view/payment/list.js
+++ b/src/Payment/view/frontend/web/js/view/payment/list.js
@@ -125,12 +125,10 @@ define([
          * @private
          */
         _reInitializeAmazonWalletWidget: function () {
-            var items = this.getRegion('payment-method-items');
-            _.find(items(), function (value) {
-                if (value.index === 'amazon_payment') {
-                    value.renderPaymentWidget();
-                }
-            }, this);
+            var child = this.getChild('amazon_payment');
+            if (child) {
+                child.renderPaymentWidget();
+            }
         },
         /**
          * hides editable content and links to prevent unexptect behaviour


### PR DESCRIPTION
Originally reported as: "we found out the handling for the InvalidPaymentMethod decline is not handled correctly."

This PR fixes a bug where 'amazon_payment' component instance could not be retrieved because of a layout region index mismatch. Region is not needed to be used here at all, so the fix just changes that to simple getChild call.

