### PR TITLE
Widgets.js loading unnecessarily

### DIFF
--- a/src/Core/Block/Config.php
+++ b/src/Core/Block/Config.php
@@ -74,6 +74,7 @@ class Config extends Template
             'customerLoginPageUrl'     => $this->url->getLoginUrl(),
             'sandboxSimulationOptions' => [],
             'loginScope'               => $this->coreHelper->getLoginScope(),
+            'allowAmLoginLoading'      => $this->coreHelper->allowAmLoginLoading(),
             'isEuPaymentRegion'        => $this->coreHelper->isEuPaymentRegion(),
             'oAuthHashRedirectUrl'     => $this->coreHelper->getOAuthRedirectUrl(),
             'isQuoteDirty'             => $this->categoryExclusionHelper->isQuoteDirty(),

--- a/src/Core/Helper/Data.php
+++ b/src/Core/Helper/Data.php
@@ -610,6 +610,20 @@ class Data extends AbstractHelper
     }
 
     /**
+     * @param string $scope
+     * @param null $scopeCode
+     * @return bool
+     */
+    public function allowAmLoginLoading($scope = ScopeInterface::SCOPE_STORE, $scopeCode = null)
+    {
+        return $this->scopeConfig->isSetFlag(
+            'customer/startup/amazon_login_in_popup',
+            $scope,
+            $scopeCode
+        );
+    }
+
+    /**
      * @param string      $scope
      * @param null|string $scopeCode
      *

--- a/src/Core/Helper/Data.php
+++ b/src/Core/Helper/Data.php
@@ -614,6 +614,16 @@ class Data extends AbstractHelper
      * @param null $scopeCode
      * @return bool
      */
+    public function isPayButtonAvailableInMinicart($scope = ScopeInterface::SCOPE_STORE, $scopeCode = null)
+    {
+        return $this->scopeConfig->isSetFlag('payment/amazon_payment/minicart_button_is_visible', $scope, $scopeCode);
+    }
+
+    /**
+     * @param string $scope
+     * @param null $scopeCode
+     * @return bool
+     */
     public function allowAmLoginLoading($scope = ScopeInterface::SCOPE_STORE, $scopeCode = null)
     {
         return $this->scopeConfig->isSetFlag(

--- a/src/Core/Helper/Data.php
+++ b/src/Core/Helper/Data.php
@@ -647,7 +647,7 @@ class Data extends AbstractHelper
     public function allowAmLoginLoading($scope = ScopeInterface::SCOPE_STORE, $scopeCode = null)
     {
         return $this->scopeConfig->isSetFlag(
-            'customer/startup/amazon_login_in_popup',
+            'payment/amazon_payment/amazon_login_in_popup',
             $scope,
             $scopeCode
         );

--- a/src/Core/etc/adminhtml/system.xml
+++ b/src/Core/etc/adminhtml/system.xml
@@ -90,6 +90,12 @@
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/amazon_payment/pwa_pp_button_is_visible</config_path>
                         </field>
+                        <field id="minicart_button_is_visible" translate="label comment" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
+                            <label>Amazon Pay button is visible in Minicart</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <config_path>payment/amazon_payment/minicart_button_is_visible</config_path>
+                            <comment>Disabling this may decrease page load time in CMS pages and homepage.</comment>
+                        </field>
                     </group>
                 </group>
                 <group id="advanced" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/src/Core/etc/adminhtml/system.xml
+++ b/src/Core/etc/adminhtml/system.xml
@@ -88,16 +88,6 @@
                             <source_model>Amazon\Core\Model\Config\Source\UpdateMechanism</source_model>
                             <config_path>payment/amazon_payment/update_mechanism</config_path>
                         </field>
-                        <field id="pwa_pp_button_is_visible" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
-                            <label>Amazon Pay button on Product Page</label>
-                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                            <config_path>payment/amazon_payment/pwa_pp_button_is_visible</config_path>
-                        </field>
-                        <field id="minicart_button_is_visible" translate="label comment" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
-                            <label>Amazon Pay button in minicart</label>
-                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                            <config_path>payment/amazon_payment/minicart_button_is_visible</config_path>
-                        </field>
                     </group>
                 </group>
                 <group id="advanced" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -118,6 +108,16 @@
                             <label>Button Size</label>
                             <source_model>Amazon\Core\Model\Config\Source\Button\Size</source_model>
                             <config_path>payment/amazon_payment/button_size</config_path>
+                        </field>
+                        <field id="pwa_pp_button_is_visible" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
+                            <label>Amazon Pay button on Product Page</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <config_path>payment/amazon_payment/pwa_pp_button_is_visible</config_path>
+                        </field>
+                        <field id="minicart_button_is_visible" translate="label comment" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">
+                            <label>Amazon Pay button in minicart</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <config_path>payment/amazon_payment/minicart_button_is_visible</config_path>
                         </field>
                     </group>
                     <group id="sales_options" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/src/Core/etc/adminhtml/system.xml
+++ b/src/Core/etc/adminhtml/system.xml
@@ -89,15 +89,14 @@
                             <config_path>payment/amazon_payment/update_mechanism</config_path>
                         </field>
                         <field id="pwa_pp_button_is_visible" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
-                            <label>Amazon Pay button is visible on Product Page</label>
+                            <label>Amazon Pay button on Product Page</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/amazon_payment/pwa_pp_button_is_visible</config_path>
                         </field>
                         <field id="minicart_button_is_visible" translate="label comment" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
-                            <label>Amazon Pay button is visible in Minicart</label>
+                            <label>Amazon Pay button in minicart</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/amazon_payment/minicart_button_is_visible</config_path>
-                            <comment>Disabling this may decrease page load time in CMS pages and homepage.</comment>
                         </field>
                     </group>
                 </group>

--- a/src/Core/etc/config.xml
+++ b/src/Core/etc/config.xml
@@ -16,6 +16,7 @@
                 <can_use_checkout>1</can_use_checkout>
                 <packstation_terms>Packstation,Pack-Station,Pack Station,PO Box,Post Office box,Locker</packstation_terms>
                 <pwa_pp_button_is_visible>1</pwa_pp_button_is_visible>
+                <minicart_button_is_visible>1</minicart_button_is_visible>
                 <button_type>full</button_type>
                 <button_size>medium</button_size>
                 <logging>1</logging>

--- a/src/Login/etc/adminhtml/system.xml
+++ b/src/Login/etc/adminhtml/system.xml
@@ -17,13 +17,17 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="customer">
-            <group id="startup">
-                <field id="amazon_login_in_popup" translate="label comment" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
-                    <label>Amazon Login available in Authentication popup</label>
-                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment>Disabling this may decrease page load time but will also remove the Amazon Login option from authentication popup.</comment>
-                </field>
+        <section id="payment">
+            <group id="amazon_payment">
+                <group id="general">
+                    <group id="options">
+                        <field id="amazon_login_in_popup" translate="label comment" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">
+                            <label>Amazon Login available in Authentication popup</label>
+                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                            <config_path>payment/amazon_payment/amazon_login_in_popup</config_path>
+                        </field>
+                    </group>
+                </group>
             </group>
         </section>
     </system>

--- a/src/Login/etc/adminhtml/system.xml
+++ b/src/Login/etc/adminhtml/system.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="customer">
+            <group id="startup">
+                <field id="amazon_login_in_popup" translate="label comment" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Amazon Login available in Authentication popup</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Disabling this may decrease page load time but will also remove the Amazon Login option from authentication popup.</comment>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/src/Login/etc/adminhtml/system.xml
+++ b/src/Login/etc/adminhtml/system.xml
@@ -19,10 +19,10 @@
     <system>
         <section id="payment">
             <group id="amazon_payment">
-                <group id="general">
-                    <group id="options">
-                        <field id="amazon_login_in_popup" translate="label comment" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">
-                            <label>Amazon Login available in Authentication popup</label>
+                <group id="advanced">
+                    <group id="frontend">
+                        <field id="amazon_login_in_popup" translate="label comment" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
+                            <label>Login with Amazon available in authentication popup</label>
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/amazon_payment/amazon_login_in_popup</config_path>
                         </field>

--- a/src/Login/etc/config.xml
+++ b/src/Login/etc/config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <customer>
+            <startup>
+                <amazon_login_in_popup>1</amazon_login_in_popup>
+            </startup>
+        </customer>
+    </default>
+</config>

--- a/src/Login/etc/config.xml
+++ b/src/Login/etc/config.xml
@@ -17,10 +17,10 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
-        <customer>
-            <startup>
+        <payment>
+            <amazon_payment>
                 <amazon_login_in_popup>1</amazon_login_in_popup>
-            </startup>
-        </customer>
+            </amazon_payment>
+        </payment>
     </default>
 </config>

--- a/src/Login/view/frontend/layout/default.xml
+++ b/src/Login/view/frontend/layout/default.xml
@@ -24,7 +24,7 @@
                         <item name="authenticationPopup" xsi:type="array">
                             <item name="children" xsi:type="array">
                                 <item name="amazon-button" xsi:type="array">
-                                    <item name="component" xsi:type="string">Amazon_Login/js/view/login-button</item>
+                                    <item name="component" xsi:type="string">Amazon_Login/js/view/login-button-wrapper</item>
                                     <item name="sortOrder" xsi:type="string">0</item>
                                     <item name="displayArea" xsi:type="string">additional-login-form-fields</item>
                                     <item name="config" xsi:type="array">

--- a/src/Login/view/frontend/web/js/view/login-button-wrapper.js
+++ b/src/Login/view/frontend/web/js/view/login-button-wrapper.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+if (window.amazonPayment.allowAmLoginLoading == true) {
+    define(['require', 'Amazon_Login/js/view/login-button'], function (require) {
+        return require("Amazon_Login/js/view/login-button");
+    });
+} else {
+    define(['require', 'uiComponent'], function (require) {
+        return require("uiComponent");
+    });
+}

--- a/src/Payment/Block/Minicart/Button.php
+++ b/src/Payment/Block/Minicart/Button.php
@@ -18,6 +18,7 @@ namespace Amazon\Payment\Block\Minicart;
 use Magento\Checkout\Model\Session;
 use Magento\Payment\Model\MethodInterface;
 use Amazon\Payment\Helper\Data;
+use Amazon\Core\Helper\Data as AmazonCoreHelper;
 use Magento\Paypal\Block\Express\InContext;
 use Magento\Framework\View\Element\Template;
 use Magento\Catalog\Block\ShortcutInterface;
@@ -59,12 +60,18 @@ class Button extends Template implements ShortcutInterface
     private $session;
 
     /**
-     * Constructor
+     * @var AmazonCoreHelper
+     */
+    private $coreHelper;
+
+    /**
+     * Button constructor.
      * @param Context $context
      * @param ResolverInterface $localeResolver
      * @param Data $mainHelper
-     * @param MethodInterface $payment
      * @param Session $session
+     * @param MethodInterface $payment
+     * @param AmazonCoreHelper $coreHelper
      * @param array $data
      */
     public function __construct(
@@ -73,6 +80,7 @@ class Button extends Template implements ShortcutInterface
         Data $mainHelper,
         Session $session,
         MethodInterface $payment,
+        AmazonCoreHelper $coreHelper,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -81,6 +89,7 @@ class Button extends Template implements ShortcutInterface
         $this->mainHelper = $mainHelper;
         $this->payment = $payment;
         $this->session = $session;
+        $this->coreHelper = $coreHelper;
     }
 
     /**
@@ -88,7 +97,8 @@ class Button extends Template implements ShortcutInterface
      */
     protected function shouldRender()
     {
-        return $this->payment->isAvailable($this->session->getQuote())
+        return $this->coreHelper->isPayButtonAvailableInMinicart()
+            && $this->payment->isAvailable($this->session->getQuote())
             && $this->isMiniCart;
     }
 


### PR DESCRIPTION
Addresses #29 

This creates admin options to turn off loading amazon main Widgets.js selectively.

Options include:
- Amazon Pay button on Product Page
- Amazon Pay button in minicart
- Amazon Login available in Authentication popup