### PR TITLE
Fixes situation where Amazon Reference ID draft state has been expired

### DIFF
--- a/src/Payment/Model/OrderInformationManagement.php
+++ b/src/Payment/Model/OrderInformationManagement.php
@@ -254,6 +254,8 @@ class OrderInformationManagement implements OrderInformationManagementInterface
     {
         $quote = $this->session->getQuote();
 
+        $quote->getExtensionAttributes()->setAmazonOrderReferenceId(null);
+
         if ($quote->getId()) {
             $quoteLink = $this->quoteLinkFactory->create()->load($quote->getId(), 'quote_id');
 

--- a/src/Payment/Plugin/ShippingInformationManagement.php
+++ b/src/Payment/Plugin/ShippingInformationManagement.php
@@ -21,6 +21,7 @@ use Closure;
 use Magento\Checkout\Api\Data\ShippingInformationInterface;
 use Magento\Checkout\Api\ShippingInformationManagementInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Amazon\Login\Helper\Session as LoginSessionHelper;
 
 class ShippingInformationManagement
 {
@@ -34,10 +35,23 @@ class ShippingInformationManagement
      */
     protected $orderInformationManagement;
 
+    /**
+     * @var LoginSessionHelper
+     */
+    protected $loginSessionHelper;
+
+    /**
+     * ShippingInformationManagement constructor.
+     * @param LoginSessionHelper $loginSessionHelper
+     * @param OrderInformationManagementInterface $orderInformationManagement
+     * @param CartRepositoryInterface $cartRepository
+     */
     public function __construct(
+        LoginSessionHelper $loginSessionHelper,
         OrderInformationManagementInterface $orderInformationManagement,
         CartRepositoryInterface $cartRepository
     ) {
+        $this->loginSessionHelper         = $loginSessionHelper;
         $this->cartRepository             = $cartRepository;
         $this->orderInformationManagement = $orderInformationManagement;
     }
@@ -54,6 +68,12 @@ class ShippingInformationManagement
 
         /* Grand total is 0, skip rest of the plugin */
         if ($quote->getGrandTotal() <= 0) {
+            return $return;
+        }
+
+        // Add Amazon Order Reference ID only when logged in using Amazon Account
+        $amazonCustomer = $this->loginSessionHelper->getAmazonCustomer();
+        if (!$amazonCustomer) {
             return $return;
         }
 


### PR DESCRIPTION
This PR is meant to solve following problem:

When user starts, but does not complete the checkout using Amazon Widget, she receives Amazon Order Reference ID which after certain period of time becomes stale. In combination with Magento persistent shopping cart this (becoming stale) causes problems when attempt to complete purchase using "standard" Magento checkout (alternative payment methods). As a result the user is always forwarded from checkout to the "My Account" page.

This PR does two things:

1. It invalidates Amazon Order Reference ID when user decides to switch to standard checkout.
2. aroundSaveAddressInformation plugin checks if user has been logged in using Amazon account and if not skips Reference ID handling.