### PR TITLE
Use table name getter to add prefix in table call.

### DIFF
--- a/src/Core/Model/Config/SimplePath.php
+++ b/src/Core/Model/Config/SimplePath.php
@@ -359,7 +359,7 @@ class SimplePath
         $db = $this->connection->getConnection();
         $select = $db->select()
             ->from(
-                ['c' => 'core_config_data']
+                ['c' => $this->connection->getTableName('core_config_data')]
             )
             ->where('c.path IN (?)', array('web/unsecure/base_url', 'web/secure/base_url'));
 


### PR DESCRIPTION
There's an oversight in the `Amazon\Core\Model\Config\SimplePath` class where a table is being called without using the proper tableName getter. This will fail on any install using table prefixes.