### PR TITLE
Add missing default configuration

### DIFF
--- a/src/Core/etc/config.xml
+++ b/src/Core/etc/config.xml
@@ -15,9 +15,14 @@
                 <can_void>1</can_void>
                 <can_use_checkout>1</can_use_checkout>
                 <packstation_terms>Packstation,Pack-Station,Pack Station,PO Box,Post Office box,Locker</packstation_terms>
+                <pwa_enabled>0</pwa_enabled>
+                <lwa_enabled>0</lwa_enabled>
+                <authorization_mode>synchronous</authorization_mode>
+                <update_mechanism>polling</update_mechanism>
                 <pwa_pp_button_is_visible>1</pwa_pp_button_is_visible>
                 <minicart_button_is_visible>1</minicart_button_is_visible>
                 <button_type>full</button_type>
+                <button_color>Gold</button_color>
                 <button_size>medium</button_size>
                 <logging>1</logging>
             </amazon_payment>


### PR DESCRIPTION
## Fix missing default configuration
It is not an error per se but default configuration lacking on some values that either are required for creating payment button or have custom source model without possible unselected state.

## Problem
Lets say that we want to programatically configure module for automatic deployment. What are required fields to set up? I can check that by looking in the admin panel. 
I deduct that i have to set all credentials plus "please select" options. The rest is already set.
I set those options. Enable module. Add product to cart and try to pay with Amazon.
As a result i get the following js error:

![Error](https://user-images.githubusercontent.com/16045377/29633940-3e9fe0d2-8848-11e7-9a28-4f3d7cb524b8.png)

It comes out that button_color is not set and therefore the null value is send to Amazon. Then I realized that though some options in admin looks like the options are selected, in reality they are not and default values for them are not provided.

## Solution
To make "what i see in admin" equal to "what is really set" I updated default values for configurations.
pwa_enabled and lwa_enabled are there for completeness even though null as a return value of scopeConfig class will be properly casted to false