### PR TITLE
Use unique id for PwA/LwA buttons

### DIFF
--- a/src/Login/view/frontend/templates/login.phtml
+++ b/src/Login/view/frontend/templates/login.phtml
@@ -14,6 +14,7 @@
  * permissions and limitations under the License.
  */
 ?>
+<?php /** @var \Amazon\Login\Block\Login $block */?>
 <div class="block block-amazon-login">
     <div class="block-title">
         <strong id="block-amazon-login-heading" role="heading" aria-level="2"><?php /* @escapeNotVerified */ echo __('Login with Amazon') ?></strong>
@@ -24,7 +25,7 @@
             <div class="primary">
                 <div class="amazon-button-container">
                     <div class="amazon-button-container__cell">
-                        <div id="LoginWithAmazon" class="login-with-amazon" data-mage-init='{"amazonButton": {"buttonType": "LwA"}}'></div>
+                        <div id="LoginWithAmazon-<?php echo $block->getJsId() ?>" class="login-with-amazon" data-mage-init='{"amazonButton": {"buttonType": "LwA"}}'></div>
                     </div>
                     <div class="amazon-button-container__cell">
                         <div class="field-tooltip toggle">

--- a/src/Payment/view/frontend/templates/minicart-button.phtml
+++ b/src/Payment/view/frontend/templates/minicart-button.phtml
@@ -33,7 +33,7 @@ $tooltipConfig = [
 <div id="minicart-amazon-pay-button" class="amazon-minicart-container">
     <div class="amazon-button-container">
         <div class="amazon-button-container__cell">
-            <div id="PayWithAmazon" class="login-with-amazon" data-mage-init='<?php /* @noEscape */ echo json_encode($config); ?>'></div>
+            <div id="PayWithAmazon-<?php echo $block->getParentBlock()->getJsId() ?>" class="login-with-amazon" data-mage-init='<?php /* @noEscape */ echo json_encode($config); ?>'></div>
         </div>
 
         <div class="amazon-button-container__cell">

--- a/src/Payment/view/frontend/templates/payment-link-product-page.phtml
+++ b/src/Payment/view/frontend/templates/payment-link-product-page.phtml
@@ -14,10 +14,11 @@
  * permissions and limitations under the License.
  */
 ?>
+<?php /** @var \Amazon\Payment\Block\ProductPagePaymentLink $block */ ?>
 <div class="amazon-button-container centered-button">
     <div class="amazon-button-container__cell">
-        <a href="javascript:;" class="amazon-addtoCart" id="amazon-addtoCart" data-mage-init='{"amazonProductAdd": {}}'></a>
-        <div id="LoginWithAmazon" class="login-with-amazon" data-mage-init='{"amazonButton": {"buttonType": "PwA"}}'></div>
+        <a href="javascript:;" class="amazon-addtoCart" id="amazon-addtoCart-<?php echo $block->getJsId() ?>" data-mage-init='{"amazonProductAdd": {}}'></a>
+        <div id="LoginWithAmazon-<?php echo $block->getJsId() ?>" class="login-with-amazon" data-mage-init='{"amazonButton": {"buttonType": "PwA"}}'></div>
     </div>
     <div class="amazon-button-container__cell">
         <div class="field-tooltip toggle">

--- a/src/Payment/view/frontend/templates/payment-link.phtml
+++ b/src/Payment/view/frontend/templates/payment-link.phtml
@@ -16,7 +16,7 @@
 ?>
 <div class="amazon-button-container centered-button">
     <div class="amazon-button-container__cell">
-        <div id="PayWithAmazon" class="login-with-amazon" data-mage-init='{"amazonButton": {"buttonType": "PwA"}}'></div>
+        <div id="PayWithAmazon-<?php echo $block->getJsId() ?>" class="login-with-amazon" data-mage-init='{"amazonButton": {"buttonType": "PwA"}}'></div>
     </div>
 
     <div class="amazon-button-container__cell">

--- a/src/Payment/view/frontend/web/js/amazon-product-add.js
+++ b/src/Payment/view/frontend/web/js/amazon-product-add.js
@@ -48,7 +48,7 @@ define([
             }, this);
 
             //setup binds for click
-            $('#amazon-addtoCart').on('click', function (e) {
+            $('.amazon-addtoCart').on('click', function (e) {
                 if ($(_this.options.addToCartForm).valid()) {
                     addedViaAmazon = true;
                     $(_this.options.addToCartForm).submit();

--- a/src/Payment/view/frontend/web/template/checkout-button.html
+++ b/src/Payment/view/frontend/web/template/checkout-button.html
@@ -23,7 +23,7 @@
     <!-- ko ifnot: (isAmazonAccountLoggedIn) -->
         <div class="amazon-button-container">
             <div class="amazon-button-container__cell">
-                <div id="PayWithAmazon" class="login-with-amazon" data-bind="mageInit: {'amazonButton':{'buttonType': 'PwA'}}"></div>
+		    <div class="login-with-amazon" data-bind="attr: {id: 'PayWithAmazon_' + displayArea}, mageInit: {'amazonButton':{'buttonType': 'PwA'}}"></div>
             </div>
 
             <div class="amazon-button-container__cell">


### PR DESCRIPTION
This PR attempts to add unique IDs to html blocks that are used for PwA/LwA buttons everywhere on the site, therefor solving an id conflict and a bug which would not allow one of the buttons to work in case there are more than one button on the page.

Internal ref: AMAZON-66