### PR TITLE
Extension now uses Amazon_Core setup_version to display version data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 bin/
 auth.json
 docs/_build/
+.idea/

--- a/src/Core/Block/Adminhtml/System/Config/Form/Version.php
+++ b/src/Core/Block/Adminhtml/System/Config/Form/Version.php
@@ -3,31 +3,27 @@
 namespace Amazon\Core\Block\Adminhtml\System\Config\Form;
 
 use Magento\Backend\Block\Template\Context;
-use Magento\Framework\Module\ModuleListInterface;
+use Amazon\Core\Helper\Data as CoreHelper;
 
 class Version extends \Magento\Config\Block\System\Config\Form\Field
 {
-    const MODULE_AMAZON_CORE = 'Amazon_Core';
-    const MODULE_AMAZON_LOGIN = 'Amazon_Login';
-    const MODULE_AMAZON_PAYMENT = 'Amazon_Payment';
-
     /**
-     * @var ModuleListInterface
+     * @var CoreHelper
      */
-    protected $_moduleList;
+    protected $coreHelper;
 
     /**
      * Version constructor.
-     * @param ModuleListInterface $moduleList
+     * @param CoreHelper $coreHelper
      * @param Context $context
      * @param array $data
      */
     public function __construct(
-        ModuleListInterface $moduleList,
+        CoreHelper $coreHelper,
         Context $context,
         array $data = []
     ) {
-        $this->_moduleList = $moduleList;
+        $this->coreHelper = $coreHelper;
         parent::__construct($context, $data);
     }
 
@@ -37,26 +33,13 @@ class Version extends \Magento\Config\Block\System\Config\Form\Field
      */
     public function render(\Magento\Framework\Data\Form\Element\AbstractElement $element)
     {
+        $version = $this->coreHelper->getVersion();
+        if (!$version) {
+            $version = __('--');
+        }
         $output = '<div style="background-color:#eee;padding:1em;border:1px solid #ddd;">';
-        $output .= __('Module version') . ': ' . $this->getVersion(self::MODULE_AMAZON_CORE);
+        $output .= __('Module version') . ': ' . $version;
         $output .= "</div>";
          return $output;
-    }
-
-    /**
-     * @param $module
-     * @return \Magento\Framework\Phrase
-     */
-    protected function getVersion($module)
-    {
-        /*
-        $version = $this->_moduleList->getOne($module);
-        if ($version && isset($version['setup_version'])) {
-            return $version['setup_version'];
-        } else {
-            return __('--');
-        }
-        */
-        return "1.1.3";
     }
 }

--- a/src/Core/Helper/Data.php
+++ b/src/Core/Helper/Data.php
@@ -20,6 +20,7 @@ use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\Module\ModuleListInterface;
 
 class Data extends AbstractHelper
 {
@@ -76,18 +77,27 @@ class Data extends AbstractHelper
     private $clientIpHelper;
 
     /**
-     * @param Context               $context
-     * @param EncryptorInterface    $encryptor
+     * @var ModuleListInterface
+     */
+    protected $moduleList;
+
+    /**
+     * Data constructor.
+     * @param ModuleListInterface $moduleList
+     * @param Context $context
+     * @param EncryptorInterface $encryptor
      * @param StoreManagerInterface $storeManager
-     * @param ClientIp              $clientIpHelper
+     * @param ClientIp $clientIpHelper
      */
     public function __construct(
+        ModuleListInterface $moduleList,
         Context $context,
         EncryptorInterface $encryptor,
         StoreManagerInterface $storeManager,
         ClientIp $clientIpHelper
     ) {
         parent::__construct($context);
+        $this->moduleList = $moduleList;
         $this->encryptor      = $encryptor;
         $this->storeManager   = $storeManager;
         $this->clientIpHelper = $clientIpHelper;
@@ -679,5 +689,15 @@ class Data extends AbstractHelper
     public function getAmazonCredentialsEncryptedFields()
     {
         return $this->amazonCredentialsEncryptedFields;
+    }
+
+    public function getVersion()
+    {
+        $version = $this->moduleList->getOne('Amazon_Core');
+        if ($version && isset($version['setup_version'])) {
+            return $version['setup_version'];
+        } else {
+            return null;
+        }
     }
 }

--- a/src/Core/Model/Config/SimplePath.php
+++ b/src/Core/Model/Config/SimplePath.php
@@ -2,7 +2,7 @@
 
 namespace Amazon\Core\Model\Config;
 
-use Amazon\Core\Helper\Data;
+use Amazon\Core\Helper\Data as CoreHelper;
 use Magento\Framework\App\State;
 use Magento\Framework\App\Cache\Type\Config as CacheTypeConfig;
 use Magento\Backend\Model\UrlInterface;
@@ -35,16 +35,18 @@ class SimplePath
     protected $_scope;
     protected $_scopeId;
 
+    protected $coreHelper;
+
     /**
      * SimplePath constructor.
      */
     public function __construct(
+        CoreHelper $coreHelper,
         \Magento\Framework\App\Config\ConfigResource\ConfigInterface $config,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Framework\App\ProductMetadataInterface $productMeta,
         \Magento\Framework\Encryption\EncryptorInterface $encryptor,
         \Magento\Framework\Message\ManagerInterface $messageManager,
-        \Magento\Framework\Module\ModuleListInterface $moduleList,
         \Magento\Framework\App\ResourceConnection $connection,
         \Magento\Framework\App\Cache\Manager $cacheManager,
         \Magento\Framework\App\Request\Http $request,
@@ -55,7 +57,7 @@ class SimplePath
         \Psr\Log\LoggerInterface $logger
     )
     {
-
+        $this->coreHelper   = $coreHelper;
         $this->config        = $config;
         $this->scopeConfig   = $scopeConfig;
         $this->productMeta   = $productMeta;
@@ -63,7 +65,6 @@ class SimplePath
         $this->backendUrl    = $backendUrl;
         $this->cacheManager  = $cacheManager;
         $this->connection    = $connection;
-        $this->moduleList    = $moduleList;
         $this->state         = $state;
         $this->request       = $request;
         $this->storeManager  = $storeManager;
@@ -384,8 +385,10 @@ class SimplePath
         }
         $urlArray = array_unique($urlArray);
 
-        $version = $this->moduleList->getOne('Amazon_Core');
-        $coreVersion = ($version && isset($version['setup_version'])) ? $version['setup_version'] : '--';
+        $coreVersion = $this->coreHelper->getVersion();
+        if (!$coreVersion) {
+            $coreVersion = '--';
+        }
 
         $currency = $this->getConfig('currency/options/default');
 


### PR DESCRIPTION
Fixes # .

From now on the extension uses core module setup_version for version information

#### Additional details about this PR

Core Helper now has method getVersion() which is from now on the definite source of extension version data (right now it uses Amazon_Core setup_version). All other functions that require this information acquire it from there.