### PR TITLE
Exclusion block from advanced options disabled

### DIFF
--- a/src/Core/etc/adminhtml/system.xml
+++ b/src/Core/etc/adminhtml/system.xml
@@ -135,22 +135,6 @@
                             <config_path>payment/amazon_payment/storename</config_path>
                         </field>
                     </group>
-                    <group id="sales_exclusions" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-                        <label>Sales Exclusions</label>
-                        <field id="packstation_terms_validation_switch" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-                            <label>Is Packing Stations Terms Validation Enabled</label>
-                            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                            <config_path>payment/amazon_payment/packstation_terms_validation_enabled</config_path>
-                        </field>
-                        <field id="packstation_terms" translate="label comment" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
-                            <label>Packing Stations Terms</label>
-                            <config_path>payment/amazon_payment/packstation_terms</config_path>
-                            <comment><![CDATA[A comma-separated list of case-insensitive terms which will be used to check whether a Customer Address is a locker or packing station.]]></comment>
-                            <depends>
-                                <field id="packstation_terms_validation_switch">1</field>
-                            </depends>
-                        </field>
-                    </group>
                     <group id="developer_options" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Developer Options</label>
                         <field id="logging" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="0">


### PR DESCRIPTION
Fixes exclusion block from advanced options

#### Additional details about this PR

Locker exclusion didn't work as intended. Disabled it until the update is available.