### PR TITLE
Invalid JSON causes problems during unserialization

### DIFF
--- a/src/Payment/composer.json
+++ b/src/Payment/composer.json
@@ -13,7 +13,7 @@
     "magento/module-sales": "^100.1.0|^101.0.0",
     "magento/module-quote": "^100.1.0|^101.0.0",
     "magento/module-payment": "^100.1.0|^100.2.0",
-    "magento/module-backend": "^100.1.0|100.2.0",
+    "magento/module-backend": "^100.1.0|100.2.0"
   },
   "autoload": {
     "files": ["registration.php"],


### PR DESCRIPTION
You can see this issue when trying to enable or disable a module via the magento script (`magento module:disable Module_Name`).