### PR TITLE
Do not load JS files when both LwA and PwA are disabled

### DIFF
--- a/src/Core/Block/Config.php
+++ b/src/Core/Block/Config.php
@@ -99,6 +99,14 @@ class Config extends Template
     /**
      * @return bool
      */
+    public function isExtensionEnabled()
+    {
+	    return ($this->coreHelper->isPwaEnabled() || $this->coreHelper->isLwaEnabled());
+    }
+
+    /**
+     * @return bool
+     */
     public function sanitizePaymentAction()
     {
         return ($this->coreHelper->getPaymentAction() === 'authorize_capture');

--- a/src/Core/view/frontend/templates/config.phtml
+++ b/src/Core/view/frontend/templates/config.phtml
@@ -15,6 +15,7 @@
  */
 ?>
 
+<?php if ($block->isExtensionEnabled()): ?>
 <script>
 
 require (['uiRegistry'], function(registry) {
@@ -22,4 +23,4 @@ require (['uiRegistry'], function(registry) {
 });
 
 </script>
-
+<?php endif ?>

--- a/src/Login/view/frontend/web/js/view/login-button-wrapper.js
+++ b/src/Login/view/frontend/web/js/view/login-button-wrapper.js
@@ -16,7 +16,7 @@
 var registry = require('uiRegistry');
 var amazonPayment = registry.get('amazonPayment');
 
-if (amazonPayment.allowAmLoginLoading == true) {
+if (amazonPayment != undefined && amazonPayment.allowAmLoginLoading == true) {
     define(['require', 'Amazon_Login/js/view/login-button'], function (require) {
         return require("Amazon_Login/js/view/login-button");
     });


### PR DESCRIPTION
This update disables loading of related JS files when both Login with Amazon and Pay with Amazon are disabled from admin.