### PR TITLE
Added shipping form validation step for the Amazon Payment in checkout

### DIFF
--- a/src/Payment/view/frontend/web/js/action/populate-shipping-address.js
+++ b/src/Payment/view/frontend/web/js/action/populate-shipping-address.js
@@ -36,7 +36,7 @@ define(
                     $.extend({}, checkoutProvider.get('shippingAddress'), shippingAddressData)
                 );
             });
-
+            $("#co-shipping-form").css("display", "none");
             checkoutDataResolver.resolveShippingAddress();
         }
 
@@ -45,16 +45,7 @@ define(
          * @private
          */
         return function () {
-            //check to see if user is logged out of amazon (otherwise shipping form won't be in DOM)
-            if (!amazonStorage.isAmazonAccountLoggedIn) {
-                populateShippingForm();
-            }
-            //subscribe to logout and trigger shippingform population when logged out.
-            amazonStorage.isAmazonAccountLoggedIn.subscribe(function (loggedIn) {
-                if (!loggedIn) {
-                    populateShippingForm();
-                }
-            });
+            populateShippingForm();
         }
     }
 );

--- a/src/Payment/view/frontend/web/js/view/checkout-widget-address.js
+++ b/src/Payment/view/frontend/web/js/view/checkout-widget-address.js
@@ -19,7 +19,8 @@ define(
         'Magento_Checkout/js/model/url-builder',
         'Magento_Checkout/js/checkout-data',
         'Magento_Checkout/js/model/checkout-data-resolver',
-	'uiRegistry'
+        'uiRegistry',
+        'Amazon_Payment/js/action/populate-shipping-address'
     ],
     function (
         $,
@@ -39,7 +40,8 @@ define(
         urlBuilder,
         checkoutData,
         checkoutDataResolver,
-	registry
+        registry,
+        populateShippingAddressAction
     ) {
         'use strict';
         var self;
@@ -119,6 +121,7 @@ define(
                         }
                         checkoutData.setShippingAddressFromData(addressConverter.quoteAddressToFormAddressData(addressData));
                         checkoutDataResolver.resolveEstimationAddress();
+                        populateShippingAddressAction();
                     }
                 ).fail(
                     function (response) {

--- a/src/Payment/view/frontend/web/js/view/shipping-address/inline-form.js
+++ b/src/Payment/view/frontend/web/js/view/shipping-address/inline-form.js
@@ -1,13 +1,14 @@
 define([
+    'jquery',
     'uiComponent',
     'ko',
     'Amazon_Payment/js/model/storage'
-], function (Component, ko, amazonStorage) {
+], function ($, Component, ko, amazonStorage) {
     'use strict';
     return Component.extend({
         defaults: {
             template: 'Amazon_Payment/shipping-address/inline-form',
-            formSelector: 'co-shipping-form'
+            formSelector: '#co-shipping-form'
         },
         initObservable: function () {
             this._super();
@@ -21,9 +22,22 @@ define([
         },
         manipulateInlineForm: function () {
             if (amazonStorage.isAmazonAccountLoggedIn()) {
-                var elem = document.getElementById(this.formSelector);
+                var errorCount = 0;
+                $(this.formSelector).find(".field").each(function () {
+                    if ($(this).hasClass('_error')) {
+                        errorCount ++;
+                        $(this).show();
+                    } else {
+                        $(this).css("display", "none");
+                    }
+                });
+                var elem = $(this.formSelector);
                 if (elem) {
-                    document.getElementById(this.formSelector).style.display = 'none';
+                    if (errorCount > 0) {
+                        $(this.formSelector).show();
+                    } else {
+                        $(this.formSelector).hide();
+                    }
                 }
             }
         }

--- a/src/Payment/view/frontend/web/js/view/shipping.js
+++ b/src/Payment/view/frontend/web/js/view/shipping.js
@@ -8,7 +8,9 @@ define(
         'Magento_Customer/js/model/customer',
         'Magento_Checkout/js/action/set-shipping-information',
         'Magento_Checkout/js/model/step-navigator',
-        'Amazon_Payment/js/model/storage'
+        'Amazon_Payment/js/model/storage',
+        'Magento_Customer/js/model/address-list',
+        'Magento_Checkout/js/model/quote'
     ],
     function (
         $,
@@ -18,10 +20,15 @@ define(
         customer,
         setShippingInformationAction,
         stepNavigator,
-        amazonStorage
+        amazonStorage,
+        addressList,
+        quote
     ) {
         'use strict';
         return Component.extend({
+            isFormInline: ko.observable(addressList().length == 0),
+            formSelector: '#co-shipping-form',
+
             initialize: function () {
                 this._super();
                 this.isNewAddressAdded(amazonStorage.isAmazonAccountLoggedIn());
@@ -48,9 +55,12 @@ define(
                     );
                 }
                 if (amazonStorage.isAmazonAccountLoggedIn() && customer.isLoggedIn()) {
-                    setShippingInformationAmazon();
+                    this.isFormInline(true);
+                    if (this.validateShippingInformation()) {
+                        setShippingInformationAmazon();
+                    }
                 } else if (amazonStorage.isAmazonAccountLoggedIn() && !customer.isLoggedIn()) {
-                    if (this.validateGuestEmail()) {
+                    if (this.validateGuestEmail() && this.validateShippingInformation()) {
                         setShippingInformationAmazon();
                     }
                 } else {
@@ -59,6 +69,61 @@ define(
                         setShippingInformationAmazon();
                     }
                 }
+            },
+
+            validateShippingInformation: function () {
+                var shippingAddress,
+                    addressData,
+                    loginFormSelector = 'form[data-role=email-with-possible-login]',
+                    emailValidationResult = customer.isLoggedIn();
+
+                if (!quote.shippingMethod()) {
+                    this.errorValidationMessage($t('Please specify a shipping method.'));
+
+                    return false;
+                }
+
+                if (!customer.isLoggedIn()) {
+                    $(loginFormSelector).validation();
+                    emailValidationResult = Boolean($(loginFormSelector + ' input[name=username]').valid());
+                }
+
+                if (this.isFormInline()) {
+                    this.source.set('params.invalid', false);
+                    this.source.trigger('shippingAddress.data.validate');
+
+                    if (this.source.get('shippingAddress.custom_attributes')) {
+                        this.source.trigger('shippingAddress.custom_attributes.data.validate');
+                    }
+
+                    if (this.source.get('params.invalid') ||
+                        !quote.shippingMethod().method_code ||
+                        !quote.shippingMethod().carrier_code ||
+                        !emailValidationResult
+                    ) {
+                        var errorCount = 0;
+                        $(this.formSelector).find(".field").each(function () {
+                            if ($(this).hasClass('_error')) {
+                                errorCount ++;
+                                $(this).show();
+                            } else {
+                                $(this).css("display", "none");
+                            }
+                        });
+                        var elem = $(this.formSelector);
+                        if (elem) {
+                            if (errorCount > 0) {
+                                $(this.formSelector).show();
+                            } else {
+                                $(this.formSelector).hide();
+                            }
+                        }
+                        return false;
+                    }
+
+
+                }
+                return this._super();
             }
         });
     }


### PR DESCRIPTION
Fixes #175 Missing province in address blocking checkout.

#### Additional details about this PR
When selecting an address in the checkout process there might be some shipping address data that is not provided by Amazon Payment but is required by Magento.
In that case the Magento's native form validation is used in order to ask the missing information from the customer.