### PR TITLE
Do not bind submit for all cases

### DIFF
--- a/src/Payment/view/frontend/web/js/catalog-add-to-cart.js
+++ b/src/Payment/view/frontend/web/js/catalog-add-to-cart.js
@@ -24,7 +24,9 @@ define([
 
         _create: function () {
             //this is overridden here and ignores the redirect option until fixed by Magento (as of 2.1)
-            this._bindSubmit();
+            if (this.options.bindSubmit) {
+                this._bindSubmit();
+            }
         },
 
         _bindSubmit: function () {


### PR DESCRIPTION
Binding submit is done conditionally after checking the relevant option. Always binding can cause multiple form submissions when another handler has been created. This causes subsequent errors like adding [multiple items to cart](https://monosnap.com/file/3ljDjDjNDmUQN3Pci3RYWOKdFMDLzQ). (Note in the video, how the 2nd click actually adds 2 more items to the cart. (Expected: 1 more item))

[Original widget and its _create method](https://github.com/magento/magento2/blob/44502ffb7f44afdcf02e3c2b95acb8538402d6dc/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js#L30) that this file is overriding for comparison 

Fixes # 
https://github.com/magento/magento2/issues/15052
Also internal JIRA MAGETWO-91097

#### Additional details about this PR