### PR TITLE
Update - added split-database support for quote-split related tables

### DIFF
--- a/src/Payment/etc/di.xml
+++ b/src/Payment/etc/di.xml
@@ -79,4 +79,11 @@
             <argument name="amazonConfig" xsi:type="object">Amazon\Payment\Model\Config</argument>
         </arguments>
     </type>
+    <type name="Magento\ScalableCheckout\Console\Command\SplitQuote">
+        <arguments>
+            <argument name="tables" xsi:type="array">
+                <item name="amazon_quote" xsi:type="string">amazon_quote</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Related to Magento 2 team request for B2B compatibility.  Quote related tables should be enabled for use with multi-database structures.