### PR TITLE
Update re: AP-369

### DIFF
--- a/src/Payment/etc/di.xml
+++ b/src/Payment/etc/di.xml
@@ -83,4 +83,16 @@
             <argument name="connectionName" xsi:type="string">checkout</argument>
         </arguments>
     </type>
+    <type name="Magento\ScalableOms\Console\Command\SplitSales">
+        <arguments>
+            <argument name="tables" xsi:type="array">
+                <item name="amazon_sales_order" xsi:type="string">amazon_sales_order</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Amazon\Payment\Model\ResourceModel\OrderLink">
+        <arguments>
+            <argument name="connectionName" xsi:type="string">sales</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Configuration in di.xml file was missing for split sales table, causing address data to be lost/not saved correctly.