### PR TITLE
Update - removed references to 'Back'

### DIFF
--- a/src/Core/i18n/de_AT.csv
+++ b/src/Core/i18n/de_AT.csv
@@ -76,7 +76,7 @@
 "My account is ready, I need to connect it to Magento","Ich habe bereits ein Amazon Pay Konto, I möchte es mit Magento verbinden."
 "or","oder"
 "I've already setup Pay with Amazon, I want to edit my settings","Ich habe Amazon Pay bereits konfiguriert, zu den Einstellungen."
-"Back","Zurück"
+"Back to register or connect an account","Zurück"
 "Updating your config with new keys, please wait...","Ihre Zugangsdaten werden übernommen, bitte warten..."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Um die automatische Kontokonfiguration mittels sicherer Übertragung der Zugangsdaten zu nutzen, aktivieren Sie bitte sichere Administrationseiten unter: General > Web > Use secure URLs in Admin."
 "Paste JSON credentials here","JSON Zugangsdaten hier einfügen"

--- a/src/Core/i18n/de_CH.csv
+++ b/src/Core/i18n/de_CH.csv
@@ -76,7 +76,7 @@
 "My account is ready, I need to connect it to Magento","Ich habe bereits ein Amazon Pay Konto, I möchte es mit Magento verbinden."
 "or","oder"
 "I've already setup Pay with Amazon, I want to edit my settings","Ich habe Amazon Pay bereits konfiguriert, zu den Einstellungen."
-"Back","Zurück"
+"Back to register or connect an account","Zurück"
 "Updating your config with new keys, please wait...","Ihre Zugangsdaten werden übernommen, bitte warten..."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Um die automatische Kontokonfiguration mittels sicherer Übertragung der Zugangsdaten zu nutzen, aktivieren Sie bitte sichere Administrationseiten unter: General > Web > Use secure URLs in Admin."
 "Paste JSON credentials here","JSON Zugangsdaten hier einfügen"

--- a/src/Core/i18n/de_DE.csv
+++ b/src/Core/i18n/de_DE.csv
@@ -76,7 +76,7 @@
 "My account is ready, I need to connect it to Magento","Ich habe bereits ein Amazon Pay Konto, I möchte es mit Magento verbinden."
 "or","oder"
 "I've already setup Pay with Amazon, I want to edit my settings","Ich habe Amazon Pay bereits konfiguriert, zu den Einstellungen."
-"Back","Zurück"
+"Back to register or connect an account","Zurück"
 "Updating your config with new keys, please wait...","Ihre Zugangsdaten werden übernommen, bitte warten..."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Um die automatische Kontokonfiguration mittels sicherer Übertragung der Zugangsdaten zu nutzen, aktivieren Sie bitte sichere Administrationseiten unter: General > Web > Use secure URLs in Admin."
 "Paste JSON credentials here","JSON Zugangsdaten hier einfügen"

--- a/src/Core/i18n/en_GB.csv
+++ b/src/Core/i18n/en_GB.csv
@@ -76,7 +76,7 @@ Logging,Logging
 "My account is ready, I need to connect it to Magento","My account is ready, I need to connect it to Magento"
 "or","or"
 "I've already setup Pay with Amazon, I want to edit my settings","I've already setup Amazon Pay, I want to edit my settings"
-"Back","Back to register or connect an account"
+"Back to register or connect an account","Back to register or connect an account"
 "Updating your config with new keys, please wait...","Updating your config with new keys, please wait..."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin."
 "Paste JSON credentials here","Paste JSON credentials here"

--- a/src/Core/i18n/en_US.csv
+++ b/src/Core/i18n/en_US.csv
@@ -23,7 +23,7 @@
 "Authorization soft decline","Authorization soft decline"
 "Authorization hard decline","Authorization hard decline"
 "Authorization timed out","Authorization timed out"
-"Back","Back"
+"Back to register or connect an account","Back to register or connect an account"
 "Button Color","Button Color"
 "Button Display Language","Button Display Language"
 "Button Size","Button Size"

--- a/src/Core/i18n/es_AR.csv
+++ b/src/Core/i18n/es_AR.csv
@@ -77,7 +77,7 @@
 "My account is ready, I need to connect it to Magento","Mi cuenta está lista, sólo tengo que vincularla a Magento."
 "or","o bien"
 "I've already setup Pay with Amazon, I want to edit my settings","Ya he configurado Amazon Pay, pero quiero modificar mi configuración."
-"Back","Volver"
+"Back to register or connect an account","Volver"
 "Updating your config with new keys, please wait...","Actualizando tu configuración con claves nuevas... Espera, por favor."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Para activar la configuración automática utilizando el intercambio seguro de claves de Amazon, accede a la página de administración de seguridad en General > Web > Utilizar URL seguras en Admin."
 "Pega las credenciales de JSON aquí"

--- a/src/Core/i18n/es_CL.csv
+++ b/src/Core/i18n/es_CL.csv
@@ -77,7 +77,7 @@
 "My account is ready, I need to connect it to Magento","Mi cuenta está lista, sólo tengo que vincularla a Magento."
 "or","o bien"
 "I've already setup Pay with Amazon, I want to edit my settings","Ya he configurado Amazon Pay, pero quiero modificar mi configuración."
-"Back","Volver"
+"Back to register or connect an account","Volver"
 "Updating your config with new keys, please wait...","Actualizando tu configuración con claves nuevas... Espera, por favor."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Para activar la configuración automática utilizando el intercambio seguro de claves de Amazon, accede a la página de administración de seguridad en General > Web > Utilizar URL seguras en Admin."
 "Pega las credenciales de JSON aquí"

--- a/src/Core/i18n/es_CO.csv
+++ b/src/Core/i18n/es_CO.csv
@@ -77,7 +77,7 @@
 "My account is ready, I need to connect it to Magento","Mi cuenta está lista, sólo tengo que vincularla a Magento."
 "or","o bien"
 "I've already setup Pay with Amazon, I want to edit my settings","Ya he configurado Amazon Pay, pero quiero modificar mi configuración."
-"Back","Volver"
+"Back to register or connect an account","Volver"
 "Updating your config with new keys, please wait...","Actualizando tu configuración con claves nuevas... Espera, por favor."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Para activar la configuración automática utilizando el intercambio seguro de claves de Amazon, accede a la página de administración de seguridad en General > Web > Utilizar URL seguras en Admin."
 "Pega las credenciales de JSON aquí"

--- a/src/Core/i18n/es_CR.csv
+++ b/src/Core/i18n/es_CR.csv
@@ -77,7 +77,7 @@
 "My account is ready, I need to connect it to Magento","Mi cuenta está lista, sólo tengo que vincularla a Magento."
 "or","o bien"
 "I've already setup Pay with Amazon, I want to edit my settings","Ya he configurado Amazon Pay, pero quiero modificar mi configuración."
-"Back","Volver"
+"Back to register or connect an account","Volver"
 "Updating your config with new keys, please wait...","Actualizando tu configuración con claves nuevas... Espera, por favor."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Para activar la configuración automática utilizando el intercambio seguro de claves de Amazon, accede a la página de administración de seguridad en General > Web > Utilizar URL seguras en Admin."
 "Pega las credenciales de JSON aquí"

--- a/src/Core/i18n/es_ES.csv
+++ b/src/Core/i18n/es_ES.csv
@@ -77,7 +77,7 @@
 "My account is ready, I need to connect it to Magento","Mi cuenta está lista, sólo tengo que vincularla a Magento."
 "or","o bien"
 "I've already setup Pay with Amazon, I want to edit my settings","Ya he configurado Amazon Pay, pero quiero modificar mi configuración."
-"Back","Volver"
+"Back to register or connect an account","Volver"
 "Updating your config with new keys, please wait...","Actualizando tu configuración con claves nuevas... Espera, por favor."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Para activar la configuración automática utilizando el intercambio seguro de claves de Amazon, accede a la página de administración de seguridad en General > Web > Utilizar URL seguras en Admin."
 "Pega las credenciales de JSON aquí"

--- a/src/Core/i18n/es_MX.csv
+++ b/src/Core/i18n/es_MX.csv
@@ -1,4 +1,4 @@
-
+6
 "click here to display the categories","haz clic aquí para mostrar las categorías"
 "No Simulation","Sin simulación"
 "Authorization soft decline","Rechazo parcial de la autorización"
@@ -77,7 +77,7 @@
 "My account is ready, I need to connect it to Magento","Mi cuenta está lista, sólo tengo que vincularla a Magento."
 "or","o bien"
 "I've already setup Pay with Amazon, I want to edit my settings","Ya he configurado Amazon Pay, pero quiero modificar mi configuración."
-"Back","Volver"
+"Back to register or connect an account","Volver"
 "Updating your config with new keys, please wait...","Actualizando tu configuración con claves nuevas... Espera, por favor."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Para activar la configuración automática utilizando el intercambio seguro de claves de Amazon, accede a la página de administración de seguridad en General > Web > Utilizar URL seguras en Admin."
 "Pega las credenciales de JSON aquí"

--- a/src/Core/i18n/es_PA.csv
+++ b/src/Core/i18n/es_PA.csv
@@ -77,7 +77,7 @@
 "My account is ready, I need to connect it to Magento","Mi cuenta está lista, sólo tengo que vincularla a Magento."
 "or","o bien"
 "I've already setup Pay with Amazon, I want to edit my settings","Ya he configurado Amazon Pay, pero quiero modificar mi configuración."
-"Back","Volver"
+"Back to register or connect an account","Volver"
 "Updating your config with new keys, please wait...","Actualizando tu configuración con claves nuevas... Espera, por favor."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Para activar la configuración automática utilizando el intercambio seguro de claves de Amazon, accede a la página de administración de seguridad en General > Web > Utilizar URL seguras en Admin."
 "Pega las credenciales de JSON aquí"

--- a/src/Core/i18n/es_PE.csv
+++ b/src/Core/i18n/es_PE.csv
@@ -77,7 +77,7 @@
 "My account is ready, I need to connect it to Magento","Mi cuenta está lista, sólo tengo que vincularla a Magento."
 "or","o bien"
 "I've already setup Pay with Amazon, I want to edit my settings","Ya he configurado Amazon Pay, pero quiero modificar mi configuración."
-"Back","Volver"
+"Back to register or connect an account","Volver"
 "Updating your config with new keys, please wait...","Actualizando tu configuración con claves nuevas... Espera, por favor."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Para activar la configuración automática utilizando el intercambio seguro de claves de Amazon, accede a la página de administración de seguridad en General > Web > Utilizar URL seguras en Admin."
 "Pega las credenciales de JSON aquí"

--- a/src/Core/i18n/es_VE.csv
+++ b/src/Core/i18n/es_VE.csv
@@ -77,7 +77,7 @@
 "My account is ready, I need to connect it to Magento","Mi cuenta está lista, sólo tengo que vincularla a Magento."
 "or","o bien"
 "I've already setup Pay with Amazon, I want to edit my settings","Ya he configurado Amazon Pay, pero quiero modificar mi configuración."
-"Back","Volver"
+"Back to register or connect an account","Volver"
 "Updating your config with new keys, please wait...","Actualizando tu configuración con claves nuevas... Espera, por favor."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Para activar la configuración automática utilizando el intercambio seguro de claves de Amazon, accede a la página de administración de seguridad en General > Web > Utilizar URL seguras en Admin."
 "Pega las credenciales de JSON aquí"

--- a/src/Core/i18n/fr_CA.csv
+++ b/src/Core/i18n/fr_CA.csv
@@ -76,7 +76,7 @@
 "My account is ready, I need to connect it to Magento","Mon compte est prêt, j'ai besoin de le connecter à Magento"
 "or","ou"
 "I've already setup Pay with Amazon, I want to edit my settings","J'ai déjà configuré le service Amazon Pay, je souhaite modifier mes paramètres"
-"Back","Retour"
+"Back to register or connect an account","Retour"
 "Updating your config with new keys, please wait...","Mise à jour de votre configuration avec les nouvelles clés, veuillez patienter..."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Pour activer la configuration automatique du compte à l'aide de l'échange de clé sécurisé d'Amazon, activez les pages d'administration sécurisées dans Général > Web > Utiliser des URL sécurisées dans Administration."
 "Paste JSON credentials here","Collez les informations d'identification JSON ici"

--- a/src/Core/i18n/fr_FR.csv
+++ b/src/Core/i18n/fr_FR.csv
@@ -76,7 +76,7 @@
 "My account is ready, I need to connect it to Magento","Mon compte est prêt, j'ai besoin de le connecter à Magento"
 "or","ou"
 "I've already setup Pay with Amazon, I want to edit my settings","J'ai déjà configuré le service Amazon Pay, je souhaite modifier mes paramètres"
-"Back","Retour"
+"Back to register or connect an account","Retour"
 "Updating your config with new keys, please wait...","Mise à jour de votre configuration avec les nouvelles clés, veuillez patienter..."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Pour activer la configuration automatique du compte à l'aide de l'échange de clé sécurisé d'Amazon, activez les pages d'administration sécurisées dans Général > Web > Utiliser des URL sécurisées dans Administration."
 "Paste JSON credentials here","Collez les informations d'identification JSON ici"

--- a/src/Core/i18n/it_CH.csv
+++ b/src/Core/i18n/it_CH.csv
@@ -76,7 +76,7 @@
 "My account is ready, I need to connect it to Magento","Il mio account è pronto, devo associarlo a Magento"
 "or","o"
 "I've already setup Pay with Amazon, I want to edit my settings","Ho già configurato Amazon Pay, voglio modificare le mie impostazioni"
-"Back","Indietro"
+"Back to register or connect an account","Indietro"
 "Updating your config with new keys, please wait...","Aggiornamento della configurazione con nuove chiavi in corso. Attendi..."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Per attivare la configurazione automatica dell'account mediante lo scambio di chiavi sicuro Amazon, attiva le pagine di amministrazione sicura in Generale > Web > Utilizza URL sicuri in Amministrazione."
 "Paste JSON credentials here","Incolla credenziali JSON qui"

--- a/src/Core/i18n/it_IT.csv
+++ b/src/Core/i18n/it_IT.csv
@@ -76,7 +76,7 @@
 "My account is ready, I need to connect it to Magento","Il mio account è pronto, devo associarlo a Magento"
 "or","o"
 "I've already setup Pay with Amazon, I want to edit my settings","Ho già configurato Amazon Pay, voglio modificare le mie impostazioni"
-"Back","Indietro"
+"Back to register or connect an account","Indietro"
 "Updating your config with new keys, please wait...","Aggiornamento della configurazione con nuove chiavi in corso. Attendi..."
 "In order to enable automatic account configuration using Amazon's secure key exchange, please turn on secure admin pages in General > Web > Use secure URLs in Admin.","Per attivare la configurazione automatica dell'account mediante lo scambio di chiavi sicuro Amazon, attiva le pagine di amministrazione sicura in Generale > Web > Utilizza URL sicuri in Amministrazione."
 "Paste JSON credentials here","Incolla credenziali JSON qui"

--- a/src/Core/view/adminhtml/templates/system/config/simplepath_admin.phtml
+++ b/src/Core/view/adminhtml/templates/system/config/simplepath_admin.phtml
@@ -65,7 +65,7 @@
 </div>
 
 <div id="amazon_simplepath_back">
-  <a href="#">&laquo; <?= $block->escapeHtml(__('Back')); ?></a>
+  <a href="#">&laquo; <?= $block->escapeHtml(__('Back to register or connect an account')); ?></a>
 </div>
 
 <script>

--- a/src/Login/i18n/en_US.csv
+++ b/src/Login/i18n/en_US.csv
@@ -23,7 +23,7 @@
 "Authorization soft decline","Authorization soft decline"
 "Authorization hard decline","Authorization hard decline"
 "Authorization timed out","Authorization timed out"
-"Back","Back"
+"Back to register or connect an account","Back to register or connect an account"
 "Button Color","Button Color"
 "Button Display Language","Button Display Language"
 "Button Size","Button Size"

--- a/src/Payment/i18n/en_US.csv
+++ b/src/Payment/i18n/en_US.csv
@@ -23,7 +23,7 @@
 "Authorization soft decline","Authorization soft decline"
 "Authorization hard decline","Authorization hard decline"
 "Authorization timed out","Authorization timed out"
-"Back","Back"
+"Back to register or connect an account","Back to register or connect an account"
 "Button Color","Button Color"
 "Button Display Language","Button Display Language"
 "Button Size","Button Size"


### PR DESCRIPTION
Per discussion - since 'Back' is already defined in Magento base code, convert admin string read 'Back to register or connect an account' and convert translation strings to translate this updated string instead of 'Back'.