### PR TITLE
Fixes the bug which causes 'Add to Cart' request to be executed twice

### DIFF
--- a/src/Payment/view/frontend/web/js/catalog-add-to-cart.js
+++ b/src/Payment/view/frontend/web/js/catalog-add-to-cart.js
@@ -23,8 +23,9 @@ define([
     $.widget('amazon.catalogAddToCart', $.mage.catalogAddToCart, {
 
         _create: function () {
-            //this is overridden here and ignores the redirect option until fixed by Magento (as of 2.1)
-            this._bindSubmit();
+            if (this.options.bindSubmit) {
+                this._bindSubmit();
+            }
         },
 
         _bindSubmit: function () {


### PR DESCRIPTION
A backward compatible alternative for

https://github.com/BearGroup/amazon-payments-magento-2-plugin/commit/d8c317df70a626cf2463072eb3cadfced5c53edc