### PR TITLE
AP-395

### DIFF
--- a/src/Login/Controller/Login/Guest.php
+++ b/src/Login/Controller/Login/Guest.php
@@ -16,13 +16,13 @@
 
 namespace Amazon\Login\Controller\Login;
 
-use Magento\Framework\App\Action\Action;
+use Amazon\Core\Client\ClientFactoryInterface;
 use Amazon\Core\Helper\Data as AmazonCoreHelper;
 use Amazon\Login\Model\Validator\AccessTokenRequestValidator;
-use Magento\Customer\Model\Url;
-use Magento\Framework\App\Action\Context;
 use Magento\Checkout\Model\Session;
-use Amazon\Core\Client\ClientFactoryInterface;
+use Magento\Customer\Model\Url;
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
 use Psr\Log\LoggerInterface;
 
 class Guest extends Action

--- a/src/Login/Model/CheckoutConfigProvider.php
+++ b/src/Login/Model/CheckoutConfigProvider.php
@@ -17,6 +17,7 @@ namespace Amazon\Login\Model;
 
 use Magento\Checkout\Model\ConfigProviderInterface;
 use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Checkout\Model\Session as CheckoutSession;
 
 class CheckoutConfigProvider implements ConfigProviderInterface
 {
@@ -26,11 +27,19 @@ class CheckoutConfigProvider implements ConfigProviderInterface
     private $customerSession;
 
     /**
-     * @param CustomerSession $customerSession
+     * @var CheckoutSession
      */
-    public function __construct(CustomerSession $customerSession)
+    private $checkoutSession;
+
+    /**
+     * CheckoutConfigProvider constructor.
+     * @param CustomerSession $customerSession
+     * @param CheckoutSession $checkoutSession
+     */
+    public function __construct(CustomerSession $customerSession, CheckoutSession $checkoutSession)
     {
         $this->customerSession = $customerSession;
+        $this->checkoutSession = $checkoutSession;
     }
 
     /**
@@ -43,6 +52,11 @@ class CheckoutConfigProvider implements ConfigProviderInterface
         /** @var \Amazon\Core\Api\Data\AmazonCustomerInterface $amazonCustomer */
         if ($amazonCustomer = $this->customerSession->getAmazonCustomer()) {
             $config['amazon_customer_email'] = $amazonCustomer->getEmail();
+        }
+
+        if (!isset($config['amazon_customer_email'])) {
+            $quote = $this->checkoutSession->getQuote();
+            $config['amazon_customer_email'] = $quote->getCustomerEmail();
         }
 
         // return a stdClass so that the resulting JSON is an empty object, not an empty array

--- a/src/Login/Model/CheckoutConfigProvider.php
+++ b/src/Login/Model/CheckoutConfigProvider.php
@@ -36,8 +36,10 @@ class CheckoutConfigProvider implements ConfigProviderInterface
      * @param CustomerSession $customerSession
      * @param CheckoutSession $checkoutSession
      */
-    public function __construct(CustomerSession $customerSession, CheckoutSession $checkoutSession)
-    {
+    public function __construct(
+        CustomerSession $customerSession,
+        CheckoutSession $checkoutSession
+    ) {
         $this->customerSession = $customerSession;
         $this->checkoutSession = $checkoutSession;
     }

--- a/src/Payment/view/frontend/web/js/view/payment/method-renderer/amazon-payment-widget.js
+++ b/src/Payment/view/frontend/web/js/view/payment/method-renderer/amazon-payment-widget.js
@@ -162,6 +162,12 @@ define(
 
                         selectBillingAddress(addressData);
                         amazonStorage.isPlaceOrderDisabled(false);
+                        if(window.checkoutConfig.amazonLogin.amazon_customer_email) {
+                            var customerField = $('#customer-email').val();
+                            if (!customerField) {
+                                $('#customer-email').val(window.checkoutConfig.amazonLogin.amazon_customer_email);
+                            }
+                        }
                     }
                 ).fail(
                     function (response) {


### PR DESCRIPTION
Ensured Amazon email address was retrieved during guest login and passed to appropriate data structures.

Added an additional check in the payment widget to check if email address was empty (as often happened on guest checkout on the first page reload) and ensured it was filled with email address when widget was done loading.