### PR TITLE
AP-387

### DIFF
--- a/src/Core/Helper/Data.php
+++ b/src/Core/Helper/Data.php
@@ -780,8 +780,8 @@ class Data extends AbstractHelper
         $isDisabled += $this->moduleList->has('Amazon_Login') ? 0 : 1;
         $isDisabled += $this->moduleList->has('Amazon_Core') ? 0 : 1;
 
-        // Make sure all of them are disabled
-        if ($isDisabled != 3) {
+        // Make sure all of them are disabled if any one of them is disabled.
+        if ($isDisabled > 0 && $isDisabled != 3) {
             $this->moduleStatusFactory->create()->setIsEnabled(false, ['Amazon_Payment', 'Amazon_Login', 'Amazon_Core']);
         }
     }


### PR DESCRIPTION
Since there are no events that can be observed reliably for a module being disabled, I added a check for when at least one module is disabled and created a means of updating when all three are not disabled.  It doesn't make sense to keep any of the modules enabled when one is disabled since they depend upon one another for various functions.