### PR TITLE
Support AP-418 - logger fix for 2.x

### DIFF
--- a/src/Core/Logger/Handler/Ipn.php
+++ b/src/Core/Logger/Handler/Ipn.php
@@ -16,7 +16,6 @@
 namespace Amazon\Core\Logger\Handler;
 
 use Magento\Framework\Logger\Handler\Base;
-use Monolog\Logger;
 
 class Ipn extends Base
 {
@@ -30,5 +29,5 @@ class Ipn extends Base
     /**
      * @var int
      */
-    protected $loggerType = Logger::DEBUG;
+    protected $loggerType = \Monolog\Logger::DEBUG;
 }

--- a/src/Core/Logger/IpnLogger.php
+++ b/src/Core/Logger/IpnLogger.php
@@ -13,21 +13,11 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-namespace Amazon\Core\Logger\Handler;
+namespace Amazon\Core\Logger;
 
-use Magento\Framework\Logger\Handler\Base;
-
-class Client extends Base
+/**
+ * Enables implementation of custom log file.
+ */
+class IpnLogger extends \Monolog\Logger
 {
-    const FILENAME = '/var/log/paywithamazon.log';
-
-    /**
-     * @var string
-     */
-    protected $fileName = self::FILENAME;
-
-    /**
-     * @var int
-     */
-    protected $loggerType = \Monolog\Logger::DEBUG;
 }

--- a/src/Core/Logger/Logger.php
+++ b/src/Core/Logger/Logger.php
@@ -13,21 +13,11 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-namespace Amazon\Core\Logger\Handler;
+namespace Amazon\Core\Logger;
 
-use Magento\Framework\Logger\Handler\Base;
-
-class Client extends Base
+/**
+ * Enables implementation of custom log file.
+ */
+class Logger extends \Monolog\Logger
 {
-    const FILENAME = '/var/log/paywithamazon.log';
-
-    /**
-     * @var string
-     */
-    protected $fileName = self::FILENAME;
-
-    /**
-     * @var int
-     */
-    protected $loggerType = \Monolog\Logger::DEBUG;
 }

--- a/src/Core/etc/di.xml
+++ b/src/Core/etc/di.xml
@@ -46,16 +46,17 @@
             <argument name="remoteAddress" xsi:type="object">Amazon_Core_RemoteAddressWithAdditionalIpHeaders</argument>
         </arguments>
     </type>
-    <virtualType name="amazonClientLogger" type="Magento\Framework\Logger\Monolog">
+    <type name="Amazon\Core\Logger\Logger">
         <arguments>
+            <argument name="name" xsi:type="string">amazonClientLogger</argument>
             <argument name="handlers" xsi:type="array">
                 <item name="debug" xsi:type="object">Amazon\Core\Logger\Handler\Client</item>
             </argument>
         </arguments>
-    </virtualType>
+    </type>
     <type name="Amazon\Core\Client\ClientFactory">
         <arguments>
-            <argument name="logger" xsi:type="object">amazonClientLogger</argument>
+            <argument name="logger" xsi:type="object">Amazon\Core\Logger\Logger</argument>
         </arguments>
     </type>
     <type name="Amazon\Core\Helper\CategoryExclusion">

--- a/src/Payment/etc/di.xml
+++ b/src/Payment/etc/di.xml
@@ -45,16 +45,17 @@
             </argument>
         </arguments>
     </type>
-    <virtualType name="amazonIpnLogger" type="Magento\Framework\Logger\Monolog">
+    <type name="Amazon\Core\Logger\IpnLogger">
         <arguments>
+            <argument name="name" xsi:type="string">amazonIpnLogger</argument>
             <argument name="handlers" xsi:type="array">
                 <item name="debug" xsi:type="object">Amazon\Core\Logger\Handler\Ipn</item>
             </argument>
         </arguments>
-    </virtualType>
+    </type>
     <type name="Amazon\Payment\Ipn\IpnHandlerFactoryInterface">
         <arguments>
-            <argument name="logger" xsi:type="object">amazonIpnLogger</argument>
+            <argument name="logger" xsi:type="object">Amazon\Core\Logger\IpnLogger</argument>
         </arguments>
     </type>
     <type name="Magento\Framework\Webapi\ErrorProcessor">


### PR DESCRIPTION
Custom loggers were not set up correctly in the di.xml file.  Added base logger classes necessary to type/write custom log.