### PR TITLE
AP-413

### DIFF
--- a/src/Payment/Gateway/Command/CaptureStrategyCommand.php
+++ b/src/Payment/Gateway/Command/CaptureStrategyCommand.php
@@ -115,7 +115,7 @@ class CaptureStrategyCommand implements CommandInterface
         }
 
         // capture on settlement/invoice
-        if (!$isCaptured && $this->isAuthorized($payment)) {
+        if (!$isCaptured && $payment->getAuthorizationTransaction()) {
             return self::CAPTURE;
         }
 
@@ -125,32 +125,6 @@ class CaptureStrategyCommand implements CommandInterface
         }
 
         return self::AUTHORIZE_CAPTURE;
-    }
-
-    /**
-     * Check if auth transaction exists
-     *
-     * @param  OrderPaymentInterface $payment
-     * @return boolean
-     */
-    private function isAuthorized(OrderPaymentInterface $payment) 
-    {
-        $filters = [];
-        $this->filterBuilder->setField('transaction_id')
-            ->setValue($payment->getLastTransId())
-            ->create();
-
-        $this->filterBuilder->setField('txn_type')
-            ->setValue(TransactionInterface::TYPE_AUTH)
-            ->create();
-
-        $searchCriteria = $this->searchCriteriaBuilder->addFilters($filters)
-            ->create();
-
-        $count = $this->transactionRepository->getList($searchCriteria)->getTotalCount();
-
-        return (boolean) $count;
-
     }
 
     /**

--- a/src/Payment/Test/Mftf/Data/AmazonPaymentData.xml
+++ b/src/Payment/Test/Mftf/Data/AmazonPaymentData.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="../../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/DataGenerator/etc/dataProfileSchema.xsd">
+    <entity name="SampleAmazonPaymentConfig" type="amazon_payment_config_state">
+        <requiredEntity type="merchant_id">SampleMerchantId</requiredEntity>
+        <requiredEntity type="access_key">SampleAccessKey</requiredEntity>
+        <requiredEntity type="secret_key">SampleSecretKey</requiredEntity>
+        <requiredEntity type="client_id">SampleClientId</requiredEntity>
+        <requiredEntity type="client_secret">SampleClientSecret</requiredEntity>
+        <requiredEntity type="payment_region">SamplePaymentRegion</requiredEntity>
+        <requiredEntity type="sandbox">SampleSandbox</requiredEntity>
+        <requiredEntity type="payment_action">SamplePaymentAction</requiredEntity>
+        <requiredEntity type="authorization_mode">SampleAuthorizationMode</requiredEntity>
+    </entity>
+    <entity name="SampleMerchantId" type="merchant_id">
+        <data key="value">someMerchantId</data>
+    </entity>
+    <entity name="SampleAccessKey" type="access_key">
+        <data key="value">someAccessKey</data>
+    </entity>
+    <entity name="SampleSecretKey" type="secret_key">
+        <data key="value">somePrivateKey</data>
+    </entity>
+    <entity name="SampleClientId" type="client_id">
+        <data key="value">someClientId</data>
+    </entity>
+    <entity name="SampleClientSecret" type="client_secret">
+        <data key="value">someClientSecret</data>
+    </entity>
+    <entity name="SamplePaymentRegion" type="payment_region">
+        <data key="value">us</data>
+    </entity>
+    <entity name="SampleSandbox" type="sandbox">
+        <data key="value">1</data>
+    </entity>
+    <entity name="SamplePaymentAction" type="payment_action">
+        <data key="value">authorize</data>
+    </entity>
+    <entity name="SampleAuthorizationMode" type="authorization_mode">
+        <data key="value">synchronous</data>
+    </entity>
+    <!-- default configuration used to restore Magento config -->
+    <entity name="DefaultAmazonPaymentConfig" type="amazon_payment_config_state">
+        <requiredEntity type="merchant_id">DefaultMerchantId</requiredEntity>
+        <requiredEntity type="access_key">DefaultAccessKey</requiredEntity>
+        <requiredEntity type="secret_key">DefaultSecretKey</requiredEntity>
+        <requiredEntity type="client_id">DefaultClientId</requiredEntity>
+        <requiredEntity type="client_secret">DefaultClientSecret</requiredEntity>
+        <requiredEntity type="payment_region">DefaultPaymentRegion</requiredEntity>
+        <requiredEntity type="sandbox">DefaultSandbox</requiredEntity>
+        <requiredEntity type="payment_action">DefaultPaymentAction</requiredEntity>
+        <requiredEntity type="authorization_mode">DefaultAuthorizationMode</requiredEntity>
+    </entity>
+    <entity name="DefaultMerchantId" type="merchant_id">
+        <data key="value"/>
+    </entity>
+    <entity name="DefaultAccessKey" type="access_key">
+        <data key="value"/>
+    </entity>
+    <entity name="DefaultSecretKey" type="secret_key">
+        <data key="value"/>
+    </entity>
+    <entity name="DefaultClientId" type="client_id">
+        <data key="value"/>
+    </entity>
+    <entity name="DefaultClientSecret" type="client_secret">
+        <data key="value"/>
+    </entity>
+    <entity name="DefaultPaymentRegion" type="payment_region">
+        <data key="value"/>
+    </entity>
+    <entity name="DefaultSandbox" type="sandbox">
+        <data key="value"/>
+    </entity>
+    <entity name="DefaultPaymentAction" type="payment_action">
+        <data key="value">authorize</data>
+    </entity>
+    <entity name="DefaultAuthorizationMode" type="authorization_mode">
+        <data key="value">synchronous</data>
+    </entity>
+</entities>

--- a/src/Payment/Test/Mftf/Metadata/amazon_payment_config-meta.xml
+++ b/src/Payment/Test/Mftf/Metadata/amazon_payment_config-meta.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<operations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:noNamespaceSchemaLocation="../../../../../../../dev/tests/acceptance/vendor/magento/magento2-functional-testing-framework/src/Magento/FunctionalTestingFramework/DataGenerator/etc/dataOperation.xsd">
+    <operation name="CreateAmazonPaymentConfigState" dataType="amazon_payment_config_state" type="create" auth="adminFormKey" url="/admin/system_config/save/section/payment/" method="POST">
+        <object key="groups" dataType="amazon_payment_config_state">
+            <object key="amazon_payment" dataType="amazon_payment_config_state">
+                <object key="groups" dataType="amazon_payment_config_state">
+                    <object key="amazon_payment" dataType="amazon_payment_config_state">
+                        <object key="groups" dataType="amazon_payment_config_state">
+                            <object key="amazon_payment_required" dataType="amazon_payment_config_state">
+                                <object key="fields" dataType="amazon_payment_config_state">
+                                    <object key="merchant_id" dataType="merchant_id">
+                                        <field key="value">string</field>
+                                    </object>
+                                    <object key="access_key" dataType="access_key">
+                                        <field key="value">string</field>
+                                    </object>
+                                    <object key="secret_key" dataType="secret_key">
+                                        <field key="value">string</field>
+                                    </object>
+                                    <object key="client_id" dataType="client_id">
+                                        <field key="value">string</field>
+                                    </object>
+                                    <object key="client_secret" dataType="client_secret">
+                                        <field key="value">string</field>
+                                    </object>
+                                    <object key="payment_region" dataType="payment_region">
+                                        <field key="value">string</field>
+                                    </object>
+                                    <object key="sandbox" dataType="sandbox">
+                                        <field key="value">string</field>
+                                    </object>
+                                    <object key="payment_action" dataType="payment_action">
+                                        <field key="value">string</field>
+                                    </object>
+                                    <object key="authorization_mode" dataType="authorization_mode">
+                                        <field key="value">string</field>
+                                    </object>
+                                </object>
+                            </object>
+                        </object>
+                    </object>
+                </object>
+            </object>
+        </object>
+    </operation>
+</operations>

--- a/src/Payment/Test/Mftf/README.md
+++ b/src/Payment/Test/Mftf/README.md
@@ -1,0 +1,3 @@
+# Amazon Payment Functional Tests
+
+Functional Test Module for Amazon Payment modules.

--- a/src/Payment/Test/Unit/Gateway/Command/CaptureStrategyCommandTest.php
+++ b/src/Payment/Test/Unit/Gateway/Command/CaptureStrategyCommandTest.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+namespace Amazon\Payment\Test\Unit\Gateway\Command;
+
+use Amazon\Payment\Gateway\Command\CaptureStrategyCommand;
+use Amazon\Core\Helper\Data;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Api\Search\SearchCriteria;
+use Magento\Payment\Gateway\Command\CommandPoolInterface;
+use Magento\Payment\Gateway\Command\GatewayCommand;
+use Magento\Payment\Gateway\Data\OrderAdapterInterface;
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Sales\Api\TransactionRepositoryInterface;
+use Magento\Sales\Model\Order\Payment;
+use Magento\Sales\Model\ResourceModel\Order\Payment\Transaction\CollectionFactory;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+/**
+ * Class CaptureStrategyCommandTest
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class CaptureStrategyCommandTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var CaptureStrategyCommand
+     */
+    private $strategyCommand;
+
+    /**
+     * @var CommandPoolInterface|MockObject
+     */
+    private $commandPool;
+
+    /**
+     * @var TransactionRepositoryInterface|MockObject
+     */
+    private $transactionRepository;
+
+    /**
+     * @var FilterBuilder|MockObject
+     */
+    private $filterBuilder;
+
+    /**
+     * @var SearchCriteriaBuilder|MockObject
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var Payment|MockObject
+     */
+    private $payment;
+
+    /**
+     * @var GatewayCommand|MockObject
+     */
+    private $command;
+
+    /**
+     * @var Data|MockObject
+     */
+    private $coreHelper;
+
+    /**
+     * Sets up base classes needed to mock the command strategy class
+     */
+    protected function setUp()
+    {
+        $this->commandPool = $this->getMockBuilder(CommandPoolInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get', '__wakeup'])
+            ->getMock();
+
+        $this->initCommandMock();
+        $this->initTransactionRepositoryMock();
+        $this->initFilterBuilderMock();
+        $this->initSearchCriteriaBuilderMock();
+
+        $this->coreHelper = $this->getMockBuilder(\Amazon\Core\Helper\Data::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->strategyCommand = new CaptureStrategyCommand(
+            $this->commandPool,
+            $this->transactionRepository,
+            $this->searchCriteriaBuilder,
+            $this->filterBuilder,
+            $this->coreHelper
+        );
+    }
+
+    /**
+     * Tests if command strategy class returns correct command value when item is authorized but not captured
+     * @throws \Magento\Payment\Gateway\Command\CommandException
+     */
+    public function testSaleExecute()
+    {
+        $paymentData = $this->getPaymentDataObjectMock();
+        $subject['payment'] = $paymentData;
+
+        $this->payment->method('getAuthorizationTransaction')
+            ->willReturn(false);
+
+        $this->payment->method('getId')
+            ->willReturn(1);
+
+        $this->coreHelper->method('getPaymentAction')->willReturn('authorize_capture');
+
+        $this->buildSearchCriteria();
+
+        $this->transactionRepository->method('getTotalCount')
+            ->willReturn(0);
+
+        $this->commandPool->method('get')
+            ->with(CaptureStrategyCommand::SALE)
+            ->willReturn($this->command);
+
+        $this->strategyCommand->execute($subject);
+    }
+
+    /**
+     * Tests if command strategy class returns correct command value when item is to be authorized and captured
+     * @throws \Magento\Payment\Gateway\Command\CommandException
+     */
+    public function testCaptureExecute()
+    {
+        $paymentData = $this->getPaymentDataObjectMock();
+        $subject['payment'] = $paymentData;
+        $lastTransId = 'transaction_id';
+
+        $this->payment->method('getAuthorizationTransaction')
+            ->willReturn(true);
+
+        $this->payment->method('getLastTransId')
+            ->willReturn($lastTransId);
+
+        $this->payment->method('getId')
+            ->willReturn(1);
+
+        $this->buildSearchCriteria();
+
+        $this->transactionRepository->method('getTotalCount')
+            ->willReturn(0);
+
+        $this->commandPool->method('get')
+            ->with(CaptureStrategyCommand::CAPTURE)
+            ->willReturn($this->command);
+
+        $this->strategyCommand->execute($subject);
+    }
+
+
+    /**
+     * Creates mock for payment data object and order payment
+     * @return MockObject
+     */
+    private function getPaymentDataObjectMock()
+    {
+        $this->payment = $this->getMockBuilder(Payment::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mock = $this->getMockBuilder(PaymentDataObject::class)
+            ->setMethods(['getPayment', 'getOrder'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mock->method('getPayment')
+            ->willReturn($this->payment);
+
+        $order = $this->getMockBuilder(OrderAdapterInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mock->method('getOrder')
+            ->willReturn($order);
+
+        return $mock;
+    }
+
+    /**
+     * Creates mock for gateway command object
+     */
+    private function initCommandMock()
+    {
+        $this->command = $this->getMockBuilder(GatewayCommand::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['execute'])
+            ->getMock();
+
+        $this->command->method('execute')
+            ->willReturn([]);
+    }
+
+    /**
+     * Creates mock for filter object
+     */
+    private function initFilterBuilderMock()
+    {
+        $this->filterBuilder = $this->getMockBuilder(FilterBuilder::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setField', 'setValue', 'create', '__wakeup'])
+            ->getMock();
+    }
+
+    /**
+     * Builds search criteria
+     */
+    private function buildSearchCriteria()
+    {
+        $this->filterBuilder->expects(self::exactly(2))
+            ->method('setField')
+            ->willReturnSelf();
+        $this->filterBuilder->expects(self::exactly(2))
+            ->method('setValue')
+            ->willReturnSelf();
+
+        $searchCriteria = new SearchCriteria();
+        $this->searchCriteriaBuilder->expects(self::exactly(2))
+            ->method('addFilters')
+            ->willReturnSelf();
+        $this->searchCriteriaBuilder->method('create')
+            ->willReturn($searchCriteria);
+
+        $this->transactionRepository->method('getList')
+            ->with($searchCriteria)
+            ->willReturnSelf();
+    }
+
+    /**
+     * Create mock for search criteria object
+     */
+    private function initSearchCriteriaBuilderMock()
+    {
+        $this->searchCriteriaBuilder = $this->getMockBuilder(SearchCriteriaBuilder::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['addFilters', 'create', '__wakeup'])
+            ->getMock();
+    }
+
+    /**
+     * Create mock for transaction repository
+     */
+    private function initTransactionRepositoryMock()
+    {
+        $this->transactionRepository = $this->getMockBuilder(TransactionRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getList', 'getTotalCount', 'delete', 'get', 'save', 'create', '__wakeup'])
+            ->getMock();
+    }
+}

--- a/src/Payment/Test/Unit/Observer/AddAmazonButtonTest.php
+++ b/src/Payment/Test/Unit/Observer/AddAmazonButtonTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+namespace Amazon\Payment\Test\Unit\Observer;
+
+use Amazon\Payment\Block\Minicart\Button;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Catalog\Block\ShortcutButtons;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Amazon\Payment\Observer\AddAmazonButton;
+
+/**
+ * Class AddAmazonButtonTest
+ *
+ * @see \Amazon\Payment\Observer\AddAmazonButton
+ */
+class AddAmazonButtonTest extends \PHPUnit\Framework\TestCase
+{
+    public function testExecute()
+    {
+
+        $objectManager = new ObjectManager($this);
+        $data = $objectManager->getObject(\Amazon\Core\Helper\Data::class);
+        $shortcutFactory = $objectManager->getObject(\Amazon\Payment\Helper\Shortcut\Factory::class);
+        $addAmazonButton = new AddAmazonButton($data, $shortcutFactory);
+
+        /** @var Observer|\PHPUnit_Framework_MockObject_MockObject $observerMock */
+        $observerMock = $this->getMockBuilder(Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var Event|\PHPUnit_Framework_MockObject_MockObject $eventMock */
+        $eventMock = $this->getMockBuilder(Event::class)
+            ->setMethods(['getContainer'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        /** @var ShortcutButtons|\PHPUnit_Framework_MockObject_MockObject $shortcutButtonsMock */
+        $shortcutButtonsMock = $this->getMockBuilder(ShortcutButtons::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $observerMock->expects(self::once())
+            ->method('getEvent')
+            ->willReturn($eventMock);
+
+        $eventMock->expects(self::once())
+            ->method('getContainer')
+            ->willReturn($shortcutButtonsMock);
+
+        $addAmazonButton->execute($observerMock);
+    }
+}

--- a/src/Payment/Test/Unit/Observer/DataAssignObserverTest.php
+++ b/src/Payment/Test/Unit/Observer/DataAssignObserverTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+namespace Amazon\Payment\Test\Unit\Observer;
+
+use Magento\Framework\DataObject;
+use Magento\Framework\Event;
+use Magento\Payment\Model\InfoInterface;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Amazon\Payment\Observer\DataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+
+/**
+ * Class DataAssignObserverTest
+ */
+class DataAssignObserverTest extends \PHPUnit\Framework\TestCase
+{
+    const KEY_SANDBOX_SIMULATION_REFERENCE = 'sandbox_simulation_reference';
+
+    public function testExecute()
+    {
+        $observerContainer = $this->getMockBuilder(Event\Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $paymentInfoModel = $this->createMock(InfoInterface::class);
+        $dataObject = new DataObject(
+            [
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    'sandbox_simulation_reference' => self::KEY_SANDBOX_SIMULATION_REFERENCE
+                ]
+            ]
+        );
+        $observerContainer->expects(static::atLeastOnce())
+            ->method('getEvent')
+            ->willReturn($event);
+        $event->expects(static::exactly(2))
+            ->method('getDataByKey')
+            ->willReturnMap(
+                [
+                    [AbstractDataAssignObserver::MODEL_CODE, $paymentInfoModel],
+                    [AbstractDataAssignObserver::DATA_CODE, $dataObject]
+                ]
+            );
+        $paymentInfoModel->expects(static::at(0))
+            ->method('setAdditionalInformation')
+            ->with('sandbox_simulation_reference', self::KEY_SANDBOX_SIMULATION_REFERENCE);
+
+        $observer = new DataAssignObserver();
+        $observer->execute($observerContainer);
+    }
+}


### PR DESCRIPTION
Added basic MFTF tests similar to those included in other Magento modules.  Added a few PHPUnit tests to get that rolling so that eventually we'll have them done over time for regression testing internally.

Made a change to the sale/settlement command strategy class to check for a parent transaction using a standard call on the payment object rather than via a custom collection call.