### PR TITLE
AP-422 - expand php version compatibility

### DIFF
--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -7,7 +7,7 @@
     "Apache-2.0"
   ],
   "require": {
-    "php": "~7.1.3||~7.2.0",
+    "php": "~7.0.13|~7.1.0|~7.2.0",
     "magento/framework": "*",
     "magento/module-config": "*",
     "magento/module-store": "*",

--- a/src/Login/composer.json
+++ b/src/Login/composer.json
@@ -7,7 +7,7 @@
     "Apache-2.0"
   ],
   "require": {
-    "php": "~7.1.3||~7.2.0",
+    "php": "~7.0.13|~7.1.0|~7.2.0",
     "amzn/amazon-pay-and-login-with-amazon-core-module": "^2.2.0",
     "magento/module-customer": "*",
     "magento/module-store": "*",

--- a/src/Payment/Test/Mftf/composer.json
+++ b/src/Payment/Test/Mftf/composer.json
@@ -7,7 +7,7 @@
     "Apache-2.0"
   ],
   "require": {
-    "php": "~7.1.3||~7.2.0",
+    "php": "~7.0.13|~7.1.0|~7.2.0",
     "amzn/amazon-pay-and-login-with-amazon-core-module": "^2.1.0",
     "magento/module-customer": "^101.0",
     "magento/module-store": "^100.1",

--- a/src/Payment/composer.json
+++ b/src/Payment/composer.json
@@ -7,7 +7,7 @@
     "Apache-2.0"
   ],
   "require": {
-    "php": "~7.1.3||~7.2.0",
+    "php": "~7.0.13|~7.1.0|~7.2.0",
     "amzn/amazon-pay-and-login-with-amazon-core-module": "^2.2.0",
     "amzn/login-with-amazon-module": "^2.2.0",
     "magento/module-eav": "*",


### PR DESCRIPTION
Fixes issues with not being able to upgrade beyond Amazon Pay 2.0.12 with php7.0.

#### Additional details about this PR