### PR TITLE
Update re: APS-83

### DIFF
--- a/src/Payment/Model/OrderInformationManagement.php
+++ b/src/Payment/Model/OrderInformationManagement.php
@@ -259,9 +259,7 @@ class OrderInformationManagement implements OrderInformationManagementInterface
     public function removeOrderReference()
     {
         $quote = $this->session->getQuote();
-
-        $quote->getExtensionAttributes()->setAmazonOrderReferenceId(null);
-
+        
         if ($quote->getId()) {
             $quoteLink = $this->quoteLinkFactory->create()->load($quote->getId(), 'quote_id');
 


### PR DESCRIPTION
Removes a redundant setter - when the QuoteLink object is deleted, no longer necessary to explicitly set the quote extension value to null - a value that is no longer acceptable as that setter is expecting an interface type. 