### PR TITLE
Add error handler on "processing redirect" page (ASD-9)

### DIFF
--- a/src/Login/view/frontend/web/js/amazon-redirect.js
+++ b/src/Login/view/frontend/web/js/amazon-redirect.js
@@ -18,10 +18,11 @@ define([
     'amazonCore',
     'amazonPaymentConfig',
     'amazonCsrf',
+    'Magento_Customer/js/customer-data',
     'mage/loader',
     'jquery/ui',
     'mage/cookies'
-], function ($, amazonCore, amazonPaymentConfig, amazonCsrf) {
+], function ($, amazonCore, amazonPaymentConfig, amazonCsrf, customerData) {
     'use strict';
 
     var self;
@@ -49,8 +50,18 @@ define([
                 amazonCore.verifyAmazonLoggedIn().then(function (loggedIn) {
                     if (loggedIn) {
                         self.redirect();
+                    } else {
+                        window.location = amazonPaymentConfig.getValue('customerLoginPageUrl');
                     }
-                }, 0);
+                }, function(error) {
+                    $('body').trigger('processStop');
+                    customerData.set('messages', {
+                        messages: [{
+                            type: 'error',
+                            text: error
+                        }]
+                    });
+                });
             }, this);
         },
 


### PR DESCRIPTION
amazon-redirect.js only handles successful sign-ins. There is no error (catch) handler defined. In case of issues, a customer would be hanging on this page.

This fix prevents the page from hanging and displays the error message from amazon.Login.authorize.