### PR TITLE
Use base currency instead of display currency for AP=enabled check

### DIFF
--- a/src/Core/Helper/Data.php
+++ b/src/Core/Helper/Data.php
@@ -581,13 +581,28 @@ class Data extends AbstractHelper
     {
         return ($this->isLwaEnabled() && $this->isPwaEnabled() && $this->isCurrentCurrencySupportedByAmazon());
     }
+    
+    /**
+     * Retrieves the base currency of the store.
+     *
+     * @param null $store
+     * @return mixed
+     */
+    public function getBaseCurrencyCode($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            'currency/options/base',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }    
 
     /**
      * @return bool
      */
     public function isCurrentCurrencySupportedByAmazon()
     {
-        return $this->getCurrentCurrencyCode() == $this->getCurrencyCode();
+        return $this->getBaseCurrencyCode() == $this->getCurrencyCode();
     }
 
     /**


### PR DESCRIPTION
Fixes #406  .

#### Additional details about this PR
Use base currency instead of display currency of store to decide whether to show Amazon Pay and Login with Amazon buttons.