### PR TITLE
Load login and pay buttons asynchronously (ASD-32)

### DIFF
--- a/src/Login/view/frontend/web/js/view/login-button-wrapper.js
+++ b/src/Login/view/frontend/web/js/view/login-button-wrapper.js
@@ -13,20 +13,12 @@
  * permissions and limitations under the License.
  */
 
-var registry = require('uiRegistry'),
-    amazonPayment = registry.get('amazonPayment');
+define(['uiRegistry', 'Amazon_Login/js/view/login-button', 'uiComponent'], function(registry, login, component) {
+    var amazonPayment = registry.get('amazonPayment');
 
-if (amazonPayment !== undefined && amazonPayment.allowAmLoginLoading === true) {
-    define(['require', 'Amazon_Login/js/view/login-button'], function (require) {
-        'use strict';
-
-        return require('Amazon_Login/js/view/login-button');
-    });
-} else {
-    define(['require', 'uiComponent'], function (require) {
-        'use strict';
-
-        return require('uiComponent');
-    });
-}
-
+    if (amazonPayment !== undefined && amazonPayment.allowAmLoginLoading === true) {
+        return login;
+    } else {
+        return component;
+    }
+});

--- a/src/Payment/view/frontend/web/js/amazon-button.js
+++ b/src/Payment/view/frontend/web/js/amazon-button.js
@@ -24,9 +24,10 @@ define([
     'uiRegistry'
 ], function ($, customerData, sectionConfig, amazonPaymentConfig, amazonCsrf) {
     'use strict';
-    var _this, $button;
+    var _this;
 
     if (amazonPaymentConfig.isDefined()) {
+
         $.widget('amazon.AmazonButton', {
             options: {
                 merchantId: null,
@@ -42,9 +43,16 @@ define([
              */
             _create: function () {
                 _this = this;
-                $button = this.element;
+                var __this = this;
                 this._verifyAmazonConfig();
-                _this._renderAmazonButton();
+
+                if (typeof OffAmazonPayments === 'undefined') {
+                    $(window).on('OffAmazonPayments', function() {
+                        __this._renderAmazonButton();
+                    });
+                } else {
+                    this._renderAmazonButton();
+                }
             },
 
             /**
@@ -53,15 +61,15 @@ define([
              */
             _verifyAmazonConfig: function () {
                 if (amazonPaymentConfig.isDefined()) {
-                    _this.options.merchantId = amazonPaymentConfig.getValue('merchantId');
-                    _this.options.buttonType = _this.options.buttonType === 'LwA' ?
+                    this.options.merchantId = amazonPaymentConfig.getValue('merchantId');
+                    this.options.buttonType = this.options.buttonType === 'LwA' ?
                         amazonPaymentConfig.getValue('buttonTypeLwa') : amazonPaymentConfig.getValue('buttonTypePwa');
-                    _this.options.buttonColor = amazonPaymentConfig.getValue('buttonColor');
-                    _this.options.buttonSize = amazonPaymentConfig.getValue('buttonSize');
-                    _this.options.redirectUrl = amazonPaymentConfig.getValue('redirectUrl');
-                    _this.options.loginPostUrl = amazonPaymentConfig.getValue('loginPostUrl');
-                    _this.options.loginScope = amazonPaymentConfig.getValue('loginScope');
-                    _this.options.buttonLanguage = amazonPaymentConfig.getValue('displayLanguage');
+                    this.options.buttonColor = amazonPaymentConfig.getValue('buttonColor');
+                    this.options.buttonSize = amazonPaymentConfig.getValue('buttonSize');
+                    this.options.redirectUrl = amazonPaymentConfig.getValue('redirectUrl');
+                    this.options.loginPostUrl = amazonPaymentConfig.getValue('loginPostUrl');
+                    this.options.loginScope = amazonPaymentConfig.getValue('loginScope');
+                    this.options.buttonLanguage = amazonPaymentConfig.getValue('displayLanguage');
                 }
             },
 
@@ -123,7 +131,7 @@ define([
              */
             usePopUp: function () {
                 return window.location.protocol === 'https:' && !$('body').hasClass('catalog-product-view') &&
-                    !_this._touchSupported();
+                    !this._touchSupported();
             },
 
             /**
@@ -131,11 +139,11 @@ define([
              * @private
              */
             _renderAmazonButton: function () {
-                OffAmazonPayments.Button($button.attr('id'), _this.options.merchantId, { //eslint-disable-line no-undef
-                    type: _this.options.buttonType,
-                    color: _this.options.buttonColor,
-                    size: _this.options.buttonSize,
-                    language: _this.options.buttonLanguage,
+                OffAmazonPayments.Button(this.element[0].id, this.options.merchantId, { //eslint-disable-line no-undef
+                    type: this.options.buttonType,
+                    color: this.options.buttonColor,
+                    size: this.options.buttonSize,
+                    language: this.options.buttonLanguage,
 
                     /**
                      * Authorization callback
@@ -155,8 +163,8 @@ define([
              */
             _getLoginOptions: function () {
                 return {
-                    scope: _this.options.loginScope,
-                    popup: _this.usePopUp(),
+                    scope: this.options.loginScope,
+                    popup: this.usePopUp(),
                     state: amazonCsrf.generateNewValue()
                 };
             }

--- a/src/Payment/view/frontend/web/js/amazon-core.js
+++ b/src/Payment/view/frontend/web/js/amazon-core.js
@@ -50,6 +50,11 @@ define([
         doLogoutOnFlagCookie(); //eslint-disable-line no-use-before-define
     }
 
+    // Widgets.js ready callback
+    window.onAmazonPaymentsReady = function() {
+        $(window).trigger('OffAmazonPayments');
+    }
+
     /**
      * Set Client ID
      * @param {String} cid

--- a/src/Payment/view/frontend/web/js/amazon-widgets-loader.js
+++ b/src/Payment/view/frontend/web/js/amazon-widgets-loader.js
@@ -13,15 +13,12 @@
  * permissions and limitations under the License.
  */
 
-var registry = require('uiRegistry');
+define(['uiRegistry'], function(registry) {
 
-if (registry.get('amazonPayment') !== undefined) {
-    var amazonPayment = registry.get('amazonPayment');
+    if (registry.get('amazonPayment') !== undefined) {
+        var amazonPayment = registry.get('amazonPayment');
 
-    define([amazonPayment.widgetUrl], function () {
-        'use strict';
-
-        //after amazon widgets file as loaded
-
-    });
-}
+        // Load external Widgets.js
+        require([amazonPayment.widgetUrl]);
+    }
+});


### PR DESCRIPTION
Fixes #405.

This required refactoring the amazon.AmazonButton widget to use the correct button scope (e.g. LwA vs PwA) and to use the window.onAmazonPaymentsReady callback (since previously Widgets.js loaded synchronously).
