### PR TITLE
ASD-111: change login redirect logic to avoid a race condition and fix some issues with ITP-enabled browsers

### DIFF
--- a/src/Login/view/frontend/web/js/amazon-redirect.js
+++ b/src/Login/view/frontend/web/js/amazon-redirect.js
@@ -44,25 +44,7 @@ define([
             // we don't have the customer's consent or invalid request
             this.redirectOnRequestWithError();
             this.setAuthStateCookies();
-            amazonCore.amazonDefined.subscribe(function () {
-                //only set this on the redirect page
-                amazon.Login.setUseCookie(true); //eslint-disable-line no-undef
-                amazonCore.verifyAmazonLoggedIn().then(function (loggedIn) {
-                    if (loggedIn) {
-                        self.redirect();
-                    } else {
-                        window.location = amazonPaymentConfig.getValue('customerLoginPageUrl');
-                    }
-                }, function(error) {
-                    $('body').trigger('processStop');
-                    customerData.set('messages', {
-                        messages: [{
-                            type: 'error',
-                            text: error
-                        }]
-                    });
-                });
-            }, this);
+            self.redirect();
         },
 
         /**

--- a/src/Payment/view/frontend/web/js/amazon-button.js
+++ b/src/Payment/view/frontend/web/js/amazon-button.js
@@ -150,6 +150,7 @@ define([
                      * Authorization callback
                      */
                     authorization: function () {
+                        amazon.Login.setUseCookie(true);
                         //eslint-disable-next-line no-undef
                         amazon.Login.authorize(_this._getLoginOptions(), _this._popupCallback());
                     }

--- a/src/Payment/view/frontend/web/js/amazon-core.js
+++ b/src/Payment/view/frontend/web/js/amazon-core.js
@@ -121,6 +121,7 @@ define([
                     interactive: 'never'
                 };
 
+            amazon.Login.setUseCookie(true);
             // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
             amazon.Login.authorize(loginOptions, function (response) { //eslint-disable-line no-undef
                 if (response.error) {


### PR DESCRIPTION
This PR addresses ASD-111 and ASD-115 by removing the Login.authorize() call from the redirect page, and enabling setUseCookie globally.