### PR TITLE
Add PHP 7.3 support to composer packages

### DIFF
--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -7,7 +7,7 @@
     "Apache-2.0"
   ],
   "require": {
-    "php": "~7.1.3||~7.2.0",
+    "php": "~7.1.3||~7.2.0||~7.3.0",
     "magento/framework": "*",
     "magento/module-sales": "*",
     "magento/module-config": "*",

--- a/src/Login/composer.json
+++ b/src/Login/composer.json
@@ -7,7 +7,7 @@
     "Apache-2.0"
   ],
   "require": {
-    "php": "~7.1.3||~7.2.0",
+    "php": "~7.1.3||~7.2.0||~7.3.0",
     "amzn/amazon-pay-and-login-with-amazon-core-module": "^3.2.13",
     "magento/framework": "^102",
     "magento/module-customer": "^102",

--- a/src/Payment/composer.json
+++ b/src/Payment/composer.json
@@ -7,7 +7,7 @@
     "Apache-2.0"
   ],
   "require": {
-    "php": "~7.1.3||~7.2.0",
+    "php": "~7.1.3||~7.2.0||~7.3.0",
     "amzn/amazon-pay-and-login-with-amazon-core-module": "^3.2.13",
     "amzn/login-with-amazon-module": "^3.2.13",
     "magento/framework": "^102",


### PR DESCRIPTION
Fixes #552  .

#### Additional details about this PR

Add PHP 7.3 support to `composer.json` for packages:

 *   Package: `amzn/amazon-pay-and-login-with-amazon-core-module`
  *  Package: `amzn/login-with-amazon-module`
  *  Package: `amzn/amazon-pay-module`