### PR TITLE
Fixed adding block for Customer edit form. PHP doc.

### DIFF
--- a/src/Payment/Block/Widget/ResetPassword.php
+++ b/src/Payment/Block/Widget/ResetPassword.php
@@ -1,16 +1,24 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: Michele
- * Date: 5/3/2018
- * Time: 11:07 AM
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
  */
-
 namespace Amazon\Payment\Block\Widget;
 
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Framework\UrlFactory;
+use Magento\Framework\UrlInterface;
 use Magento\Customer\Model\Session;
 use Amazon\Login\Api\CustomerLinkRepositoryInterface;
 
@@ -19,13 +27,28 @@ use Amazon\Login\Api\CustomerLinkRepositoryInterface;
  */
 class ResetPassword extends Template
 {
-
+    /**
+     * @var UrlInterface
+     */
     private $urlModel;
 
+    /**
+     * @var Session
+     */
     private $session;
 
+    /**
+     * @var CustomerLinkRepositoryInterface
+     */
     private $customerLink;
 
+    /**
+     * @param Context                         $context
+     * @param UrlFactory                      $urlFactory
+     * @param Session                         $session
+     * @param CustomerLinkRepositoryInterface $customerLink
+     * @param array                           $data
+     */
     public function __construct(
         Context $context,
         UrlFactory $urlFactory,
@@ -39,6 +62,9 @@ class ResetPassword extends Template
         $this->customerLink = $customerLink;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function _prepareLayout()
     {
         parent::_prepareLayout();
@@ -48,6 +74,11 @@ class ResetPassword extends Template
         return $this;
     }
 
+    /*
+     * Check to show link for customer
+     *
+     * @return bool
+     */
     public function displayAmazonInfo()
     {
         $id = $this->session->getCustomer()->getId();
@@ -61,6 +92,11 @@ class ResetPassword extends Template
         return false;
     }
 
+    /* 
+     * Get link for block
+     *
+     * @return string
+     */
     public function getLink()
     {
         $url = $this->urlModel->getUrl('customer/account/forgotpassword');

--- a/src/Payment/view/frontend/layout/customer_account_edit.xml
+++ b/src/Payment/view/frontend/layout/customer_account_edit.xml
@@ -1,15 +1,25 @@
 <?xml version="1.0"?>
 <!--
 /**
- * Copyright © Magento, Inc. All rights reserved.
- * See COPYING.txt for license details.
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
  */
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <update handle="customer_account"/>
     <body>
         <referenceContainer name="form.additional.info">
-            <block class="Amazon\Payment\Block\Widget\ResetPassword" name="amazon.pay.password.reset" before="-" template="Amazon_Payment::widget/resetpassword.phtml" cacheable="false" />
+            <block class="Amazon\Payment\Block\Widget\ResetPassword" name="amazon.pay.password.reset" before="-" template="Amazon_Payment::widget/resetpassword.phtml" ifconfig="payment/amazon_payment/active" />
         </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
Fixes:
1. Removed cachable="false" - Customer Account pages aren`t cached at all
2. Added link to form if Amazon Payment is enabled
3. Fixed copyright for related files.
4. Added PHP doc.