### PR TITLE
[ASD-197] Shipping JS implementation improvement 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following table provides an overview on which Git branch is compatible to wh
 
 | Magento Version  | Github Branch | Latest release |
 | ------------- | ------------- | ------------- |
-| 2.1.0 - 2.2.3  | [1.x](https://github.com/amzn/amazon-payments-magento-2-plugin/tree/1.x) | 1.2.8 |
+| 2.1.0 - 2.2.3  | [1.x](https://github.com/amzn/amazon-payments-magento-2-plugin/tree/1.x) | 1.3.0 |
 | 2.2.4 - 2.2.5  | [2.x](https://github.com/amzn/amazon-payments-magento-2-plugin/tree/2.x) | 2.0.16 |
 | 2.2.6 - 2.2.x  | [2.1.x](https://github.com/amzn/amazon-payments-magento-2-plugin/tree/2.1.x) | 2.3.1 |
 | 2.3.0 and above  | [master](https://github.com/amzn/amazon-payments-magento-2-plugin/tree/master) | 3.3.1 |

--- a/src/Payment/Plugin/CheckoutProcessor.php
+++ b/src/Payment/Plugin/CheckoutProcessor.php
@@ -62,12 +62,6 @@ class CheckoutProcessor
         ['children']['payment'];
 
         if (!$quote->isVirtual() && $this->amazonHelper->isPwaEnabled()) {
-            $shippingConfig['component'] = 'Amazon_Payment/js/view/shipping';
-            $shippingConfig['children']['customer-email']['component'] = 'Amazon_Payment/js/view/form/element/email';
-            $shippingConfig['children']['address-list']['component'] = 'Amazon_Payment/js/view/shipping-address/list';
-            $shippingConfig['children']['shipping-address-fieldset']['children']
-            ['inline-form-manipulator']['component'] = 'Amazon_Payment/js/view/shipping-address/inline-form';
-
             $paymentConfig['children']['payments-list']['component'] = 'Amazon_Payment/js/view/payment/list';
         } else {
             unset($shippingConfig['children']['customer-email']['children']['amazon-button-region']);

--- a/src/Payment/view/frontend/layout/checkout_index_index.xml
+++ b/src/Payment/view/frontend/layout/checkout_index_index.xml
@@ -45,8 +45,20 @@
                                         <item name="shipping-step" xsi:type="array">
                                             <item name="children" xsi:type="array">
                                                 <item name="shippingAddress" xsi:type="array">
+                                                    <item name="component" xsi:type="string">Amazon_Payment/js/view/shipping</item>
                                                     <item name="children" xsi:type="array">
+                                                        <item name="address-list" xsi:type="array">
+                                                            <item name="component" xsi:type="string">Amazon_Payment/js/view/shipping-address/list</item>
+                                                        </item>
+                                                        <item name="shipping-address-fieldset" xsi:type="array">
+                                                            <item name="children" xsi:type="array">
+                                                                <item name="inline-form-manipulator" xsi:type="array">
+                                                                    <item name="component" xsi:type="string">Amazon_Payment/js/view/shipping-address/inline-form</item>
+                                                                </item>
+                                                            </item>
+                                                        </item>
                                                         <item name="customer-email" xsi:type="array">
+                                                            <item name="component" xsi:type="string">Amazon_Payment/js/view/form/element/email</item>
                                                             <item name="children" xsi:type="array">
                                                                 <item name="amazon-button-region" xsi:type="array">
                                                                     <item name="component" xsi:type="string">uiComponent</item>


### PR DESCRIPTION
Fixes #

the plugin overwrites the shippingAddress JS component. this gives issues with other extensions that also use shippingAddress or try to extend/overwrite the JS component.
Right now, modification of the checkout page's jsLayout is happening in a plugin because it's conditional on $quote->isVirtual(), which must be evaluated at runtime for the current quote.
Solution: moving that conditional to the layout xml using a helper class

#### Additional details about this PR
This PR address issue described here: https://github.com/amzn/amazon-payments-magento-2-plugin/issues/565