### PR TITLE
ASD-333: Fixed PHP Fatal error

### DIFF
--- a/src/PayV2/Block/Adminhtml/System/Config/Form/Version.php
+++ b/src/PayV2/Block/Adminhtml/System/Config/Form/Version.php
@@ -38,7 +38,7 @@ class Version extends \Magento\Config\Block\System\Config\Form\Field
      * @param \Magento\Framework\Data\Form\Element\AbstractElement $element
      * @return string
      */
-    public function render($element)
+    public function render(\Magento\Framework\Data\Form\Element\AbstractElement $element)
     {
         $module = $this->moduleList->getOne('Amazon_PayV2');
         $version = $module['setup_version'] ?? __('--');


### PR DESCRIPTION
Declaration of Amazon\PayV2\Block\Adminhtml\System\Config\Form\Version::render($element) must be compatible with Magento\Framework\Data\Form\Element\Renderer\RendererInterface::render(Magento\Framework\Data\Form\Element\AbstractElement $element)