### PR TITLE
ASD-287: Fixed createCheckoutSession return type

### DIFF
--- a/src/PayV2/Api/CheckoutSessionManagementInterface.php
+++ b/src/PayV2/Api/CheckoutSessionManagementInterface.php
@@ -22,7 +22,7 @@ interface CheckoutSessionManagementInterface
 {
     /**
      * @param mixed $cartId
-     * @return string
+     * @return \Amazon\PayV2\Api\Data\CheckoutSessionInterface
      */
     public function createCheckoutSession($cartId);
 

--- a/src/PayV2/CustomerData/CheckoutSession.php
+++ b/src/PayV2/CustomerData/CheckoutSession.php
@@ -94,6 +94,6 @@ class CheckoutSession implements SectionSourceInterface
      */
     public function createCheckoutSessionId()
     {
-        return $this->checkoutSessionManagement->createCheckoutSession($this->session->getQuote());
+        return $this->checkoutSessionManagement->createCheckoutSession($this->session->getQuote())->getSessionId();
     }
 }

--- a/src/PayV2/Model/CheckoutSessionManagement.php
+++ b/src/PayV2/Model/CheckoutSessionManagement.php
@@ -134,22 +134,19 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
      */
     public function createCheckoutSession($cartId)
     {
-        $result = null;
+        $checkoutSession = $this->checkoutSessionFactory->create();
         $this->cancelCheckoutSession($cartId);
         if ($this->amazonConfig->isEnabled()) {
             $response = $this->amazonAdapter->createCheckoutSession($this->storeManager->getStore()->getId());
             if (isset($response['checkoutSessionId'])) {
-                $checkoutSession = $this->checkoutSessionFactory->create([
-                    'data' => [
-                        CheckoutSessionInterface::KEY_QUOTE_ID => $this->getCart($cartId)->getId(),
-                        CheckoutSessionInterface::KEY_SESSION_ID => $response['checkoutSessionId'],
-                    ]
+                $checkoutSession->setData([
+                    CheckoutSessionInterface::KEY_QUOTE_ID => $this->getCart($cartId)->getId(),
+                    CheckoutSessionInterface::KEY_SESSION_ID => $response['checkoutSessionId']
                 ]);
                 $this->checkoutSessionRepository->save($checkoutSession);
-                $result = $checkoutSession->getSessionId();
             }
         }
-        return $result;
+        return $checkoutSession;
     }
 
     /**


### PR DESCRIPTION
Fixes createCheckoutSession return type to return CheckoutSessionInterface.
This way createCheckoutSession REST API method will return a JSON object that can be used by AmazonPay button config.