### PR TITLE
Add Sort Order configuration option for Amazon Pay in list of payment methods

### DIFF
--- a/src/Core/etc/adminhtml/system.xml
+++ b/src/Core/etc/adminhtml/system.xml
@@ -145,6 +145,15 @@
                             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                             <config_path>payment/amazonlogin/active</config_path>
                         </field>
+                        <field id="sort_order" translate="label comment" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
+                            <label>Sort Order</label>
+                            <comment><![CDATA[Sort order of Amazon Pay in the list of payment methods during the final step of checkout.]]></comment>
+                            <frontend_class>validate-number</frontend_class>
+                            <config_path>payment/amazonlogin/sort_order</config_path>
+                            <depends>
+                                <field id="amazonloggin">1</field>
+                            </depends>
+                        </field>
                     </group>
                     <group id="sales_options" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                         <label>Sales Options</label>

--- a/src/Payment/etc/config.xml
+++ b/src/Payment/etc/config.xml
@@ -23,6 +23,7 @@
                 <model>Amazon\Payment\Model\Method\AmazonLoginMethod</model>
                 <order_status>pending</order_status>
                 <title>Amazon Pay</title>
+                <sort_order>0</sort_order>
                 <allowspecific>0</allowspecific>
             </amazonlogin>
             <amazon_payment>


### PR DESCRIPTION
Add a 'Sort Order' configuration option to the admin for Amazon Pay in the list of payment methods

Fixes #440.

#### Additional details about this PR

* Example in admin:

<img width="696" alt="Sort Order option in Admin" src="https://user-images.githubusercontent.com/334375/89015319-219f0680-d317-11ea-9c0e-16ccc55ee203.png">

* Example on front-end:
<img width="725" alt="Screenshot 2020-07-31 at 10 19 53" src="https://user-images.githubusercontent.com/334375/89015536-7cd0f900-d317-11ea-9dd8-27fb18bc770e.png">

