### PR TITLE
APF-222: fix for invoicing issue

### DIFF
--- a/src/PayV2/Gateway/Response/AuthorizationSaleHandler.php
+++ b/src/PayV2/Gateway/Response/AuthorizationSaleHandler.php
@@ -61,12 +61,13 @@ class AuthorizationSaleHandler implements HandlerInterface
             /** @var Payment $payment */
             $payment = $paymentDO->getPayment();
 
-            $payment->setTransactionId($response['chargeId']);
+            $payment->setTransactionId($response['checkoutSessionId']);
 
             $chargeState = $response['statusDetails']['state'];
 
             switch ($chargeState) {
                 case 'Authorized':
+                case 'Open':
                     $payment->setIsTransactionClosed(false);
                     break;
                 case 'AuthorizationInitiated':

--- a/src/PayV2/Gateway/Response/AuthorizationSaleHandler.php
+++ b/src/PayV2/Gateway/Response/AuthorizationSaleHandler.php
@@ -62,40 +62,7 @@ class AuthorizationSaleHandler implements HandlerInterface
             $payment = $paymentDO->getPayment();
 
             $payment->setTransactionId($response['checkoutSessionId']);
-
-            $chargeState = $response['statusDetails']['state'];
-
-            switch ($chargeState) {
-                case 'Authorized':
-                case 'Open':
-                    $payment->setIsTransactionClosed(false);
-                    break;
-                case 'AuthorizationInitiated':
-                    $payment->setIsTransactionClosed(false);
-                    $this->setPending($payment);
-                    $this->asyncManagement->queuePendingAuthorization($response['chargeId']);
-                    break;
-                case 'Captured':
-                    $payment->setIsTransactionClosed(true);
-                    break;
-                case 'CaptureInitiated':
-                    $payment->setIsTransactionClosed(false);
-                    break;
-            }
+            $payment->setIsTransactionClosed(false);
         }
-    }
-
-    /**
-     * Set order as pending review
-     *
-     * @param Payment $payment
-     */
-    private function setPending($payment)
-    {
-        $order = $payment->getOrder();
-        $payment->setIsTransactionPending(true);
-        $order->setState(\Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW)->setStatus(
-            \Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW
-        );
     }
 }

--- a/src/PayV2/Model/Adapter/AmazonPayV2Adapter.php
+++ b/src/PayV2/Model/Adapter/AmazonPayV2Adapter.php
@@ -362,8 +362,8 @@ class AmazonPayV2Adapter
             ]
         ];
 
-        $response = $this->clientFactory->create($storeId)->completeCheckoutSession($sessionId, json_encode($payload));
-        return $response;
+        $rawResponse = $this->clientFactory->create($storeId)->completeCheckoutSession($sessionId, json_encode($payload));
+        return $this->processResponse($rawResponse, __FUNCTION__);
     }
 
     /**

--- a/src/PayV2/Model/Adapter/AmazonPayV2Adapter.php
+++ b/src/PayV2/Model/Adapter/AmazonPayV2Adapter.php
@@ -21,6 +21,10 @@ namespace Amazon\PayV2\Model\Adapter;
  */
 class AmazonPayV2Adapter
 {
+    const PAYMENT_INTENT_CONFIRM = 'Confirm';
+    const PAYMENT_INTENT_AUTHORIZE = 'Authorize';
+    const PAYMENT_INTENT_AUTHORIZE_WITH_CAPTURE = 'AuthorizeWithCapture';
+
     /**
      * @var \Amazon\PayV2\Client\ClientFactoryInterface
      */
@@ -151,9 +155,10 @@ class AmazonPayV2Adapter
      *
      * @param $quote
      * @param $checkoutSessionId
+     * @param $paymentIntent
      * @return mixed
      */
-    public function updateCheckoutSession($quote, $checkoutSessionId)
+    public function updateCheckoutSession($quote, $checkoutSessionId, $paymentIntent = self::PAYMENT_INTENT_AUTHORIZE)
     {
         $storeId = $quote->getStoreId();
         $store = $quote->getStore();
@@ -171,7 +176,7 @@ class AmazonPayV2Adapter
                 'checkoutResultReturnUrl' => $this->amazonConfig->getCheckoutResultUrl()
             ],
             'paymentDetails' => [
-                'paymentIntent' => 'Authorize',
+                'paymentIntent' => $paymentIntent,
                 'canHandlePendingAuthorization' => $this->amazonConfig->canHandlePendingAuthorization(),
                 'chargeAmount' => $this->createPrice($quote->getGrandTotal(), $quote->getQuoteCurrencyCode()),
             ],
@@ -323,25 +328,13 @@ class AmazonPayV2Adapter
      * AuthorizeClient and SaleClient Gateway Command
      *
      * @param $data
+     * @return array|mixed
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
-    public function authorize($data, $captureNow = false)
+    public function authorize($data)
     {
         $quote = $this->quoteRepository->get($data['quote_id']);
         $response = $this->getCheckoutSession($quote->getStoreId(), $data['amazon_checkout_session_id']);
-        if (!empty($response['chargeId'])) {
-            // Get charge for async checkout
-            $charge = $this->getCharge($quote->getStoreId(), $response['chargeId']);
-
-            if ($captureNow && $charge['statusDetails']['state'] == 'Authorized') {
-                $response = $this->captureCharge(
-                    $quote->getStoreId(),
-                    $response['chargeId'],
-                    $quote->getGrandTotal(),
-                    $quote->getStore()->getCurrentCurrency()->getCode()
-                );
-            }
-            $response['charge'] = $charge;
-        }
 
         return $response;
     }

--- a/src/PayV2/Model/CheckoutSessionManagement.php
+++ b/src/PayV2/Model/CheckoutSessionManagement.php
@@ -17,10 +17,14 @@
 namespace Amazon\PayV2\Model;
 
 use Amazon\PayV2\Api\Data\CheckoutSessionInterface;
+use Amazon\PayV2\Model\Config\Source\PaymentAction;
+use Amazon\PayV2\Model\AsyncManagement;
 use http\Exception\UnexpectedValueException;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Framework\Validator\Exception as ValidatorException;
 use Magento\Framework\Webapi\Exception as WebapiException;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order\Payment;
 use Magento\Sales\Api\Data\TransactionInterface as Transaction;
 
 class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionManagementInterface
@@ -44,6 +48,16 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
      * @var \Magento\Quote\Api\CartRepositoryInterface
      */
     private $cartRepository;
+
+    /**
+     * @var \Magento\Sales\Api\OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var \Magento\Sales\Api\OrderPaymentRepositoryInterface
+     */
+    private $paymentRepository;
 
     /**
      * @var \Magento\Framework\Validator\Factory
@@ -101,6 +115,11 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
     private $amazonAdapter;
 
     /**
+     * @var AsyncManagement
+     */
+    private $asyncManagement;
+
+    /**
      * @var array
      */
     private $amazonSessions = [];
@@ -116,15 +135,18 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
      * @param \Magento\Quote\Model\QuoteIdMaskFactory $quoteIdMaskFactory
      * @param \Magento\Quote\Api\CartManagementInterface $cartManagement
      * @param \Magento\Quote\Api\CartRepositoryInterface $cartRepository
-     * @param \Magento\Framework\Validator\Factory $validatorFactory,
-     * @param \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollectionFactory,
-     * @param \Amazon\PayV2\Domain\AmazonAddressFactory $amazonAddressFactory,
-     * @param \Amazon\PayV2\Helper\Address $addressHelper,
+     * @param \Magento\Sales\Api\OrderRepositoryInterface $orderRepository
+     * @param \Magento\Sales\Api\OrderPaymentRepositoryInterface $paymentRepository
+     * @param \Magento\Framework\Validator\Factory $validatorFactory ,
+     * @param \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollectionFactory ,
+     * @param \Amazon\PayV2\Domain\AmazonAddressFactory $amazonAddressFactory ,
+     * @param \Amazon\PayV2\Helper\Address $addressHelper ,
      * @param \Amazon\PayV2\Api\Data\CheckoutSessionInterfaceFactory $checkoutSessionFactory
      * @param \Amazon\PayV2\Api\CheckoutSessionRepositoryInterface $checkoutSessionRepository
      * @param \Amazon\PayV2\Helper\Data $amazonHelper
      * @param AmazonConfig $amazonConfig
      * @param Adapter\AmazonPayV2Adapter $amazonAdapter
+     * @param AsyncManagement $asyncManagement
      * @param \Magento\Sales\Api\TransactionRepositoryInterface $transactionRepository
      * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
      */
@@ -133,6 +155,8 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
         \Magento\Quote\Model\QuoteIdMaskFactory $quoteIdMaskFactory,
         \Magento\Quote\Api\CartManagementInterface $cartManagement,
         \Magento\Quote\Api\CartRepositoryInterface $cartRepository,
+        \Magento\Sales\Api\OrderRepositoryInterface $orderRepository,
+        \Magento\Sales\Api\OrderPaymentRepositoryInterface $paymentRepository,
         \Magento\Framework\Validator\Factory $validatorFactory,
         \Magento\Directory\Model\ResourceModel\Country\CollectionFactory $countryCollectionFactory,
         \Amazon\PayV2\Domain\AmazonAddressFactory $amazonAddressFactory,
@@ -142,6 +166,7 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
         \Amazon\PayV2\Helper\Data $amazonHelper,
         \Amazon\PayV2\Model\AmazonConfig $amazonConfig,
         \Amazon\PayV2\Model\Adapter\AmazonPayV2Adapter $amazonAdapter,
+        \Amazon\PayV2\Model\AsyncManagement $asyncManagement,
         \Magento\Sales\Api\TransactionRepositoryInterface $transactionRepository,
         \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder
     )
@@ -150,6 +175,8 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->cartManagement = $cartManagement;
         $this->cartRepository = $cartRepository;
+        $this->orderRepository = $orderRepository;
+        $this->paymentRepository = $paymentRepository;
         $this->validatorFactory = $validatorFactory;
         $this->countryCollectionFactory = $countryCollectionFactory;
         $this->amazonAddressFactory = $amazonAddressFactory;
@@ -159,6 +186,7 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
         $this->amazonHelper = $amazonHelper;
         $this->amazonConfig = $amazonConfig;
         $this->amazonAdapter = $amazonAdapter;
+        $this->asyncManagement = $asyncManagement;
         $this->transactionRepository = $transactionRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
     }
@@ -386,12 +414,16 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
     {
         $result = null;
         $checkoutSession = null;
+        $paymentIntent = Adapter\AmazonPayV2Adapter::PAYMENT_INTENT_AUTHORIZE;
+        if ($this->amazonConfig->getPaymentAction() == PaymentAction::AUTHORIZE_AND_CAPTURE) {
+            $paymentIntent = Adapter\AmazonPayV2Adapter::PAYMENT_INTENT_AUTHORIZE_WITH_CAPTURE;
+        }
         $cart = $this->getCart($cartId);
         if ($this->amazonConfig->isEnabled()) {
             $checkoutSession = $this->getCheckoutSessionForCart($cart);
         }
         if ($checkoutSession && $cart->getIsActive()) {
-            $response = $this->amazonAdapter->updateCheckoutSession($cart, $checkoutSession->getSessionId());
+            $response = $this->amazonAdapter->updateCheckoutSession($cart, $checkoutSession->getSessionId(), $paymentIntent);
             if (!empty($response['webCheckoutDetails']['amazonPayRedirectUrl'])) {
                 $result = $response['webCheckoutDetails']['amazonPayRedirectUrl'];
                 $checkoutSession->setUpdated();
@@ -426,18 +458,35 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
 
     /**
      * Swaps the checkoutSessionId that was originally stored on the sales_payment_transaction record with the
-     * real payment charge (transaction) id
+     * real payment charge (transaction) id. Also updates the payment's last transaction id to match.
      *
-     * @param array $amazonResult must have two keys, 'checkoutSessionId' and 'chargeId'
+     * @param $chargeId
+     * @param $payment
+     * @param $transaction
+     * @return void
      */
-    private function updateTransactionId($amazonResult)
+    private function updateTransactionId($chargeId, $payment, $transaction)
     {
-        if (!array_key_exists('checkoutSessionId', $amazonResult) || !array_key_exists('chargeId', $amazonResult)) {
-            throw new Exception('Required data not set on result');
-        }
+        $transaction->setTxnId($chargeId);
+        $this->transactionRepository->save($transaction);
 
-        $transaction = $this->getTransaction($amazonResult['checkoutSessionId'], Transaction::TYPE_AUTH);
-        $transaction->setTxnId($amazonResult['chargeId'])->save();
+        $payment->setLastTransId($chargeId);
+        $this->paymentRepository->save($payment);
+    }
+
+    /**
+     * Set order as pending review
+     *
+     * @param Payment $payment
+     */
+    private function setPending($payment)
+    {
+        $order = $payment->getOrder();
+        $payment->setIsTransactionPending(true);
+        $order->setState(\Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW)->setStatus(
+            \Magento\Sales\Model\Order::STATE_PAYMENT_REVIEW
+        );
+        $this->orderRepository->save($order);
     }
 
     /**
@@ -457,8 +506,28 @@ class CheckoutSessionManagement implements \Amazon\PayV2\Api\CheckoutSessionMana
                     $cart->setCheckoutMethod(\Magento\Quote\Api\CartManagementInterface::METHOD_GUEST);
                 }
                 $result = $this->cartManagement->placeOrder($cart->getId());
+                $order = $this->orderRepository->get($result);
                 $amazonResult = $this->amazonAdapter->completeCheckoutSession($cart->getStoreId(), $checkoutSession->getSessionId(), $cart->getBaseGrandTotal() , $cart->getBaseCurrencyCode());
-                $this->updateTransactionId($amazonResult);
+                $chargeId = $amazonResult['chargeId'];
+                $amazonCharge = $this->amazonAdapter->getCharge($cart->getStoreId(), $chargeId);
+                $payment = $order->getPayment();
+                $transaction = $this->getTransaction($amazonResult['checkoutSessionId']);
+
+                $chargeState = $amazonCharge['statusDetails']['state'];
+                switch ($chargeState) {
+                    case 'AuthorizationInitiated':
+                        $payment->setIsTransactionClosed(false);
+                        $this->setPending($payment);
+                        $transaction->setIsClosed(false);
+                        $this->asyncManagement->queuePendingAuthorization($chargeId);
+                        break;
+                    case 'Captured':
+                        $payment->setIsTransactionClosed(true);
+                        $transaction->setIsClosed(true);
+                        break;
+                }
+
+                $this->updateTransactionId($chargeId, $payment, $transaction);
                 $checkoutSession->complete();
                 $this->checkoutSessionRepository->save($checkoutSession);
             } catch (\Exception $e) {

--- a/src/PayV2/view/frontend/templates/config.phtml
+++ b/src/PayV2/view/frontend/templates/config.phtml
@@ -23,7 +23,7 @@ require (['uiRegistry'], function(registry) {
 });
 
 <?php if ($block->getRequest()->getFrontName() != 'checkout'): ?>
-require (['jquery', 'Amazon_PayV2/js/model/storage'], function($, amazonStorage) {
+require (['Amazon_PayV2/js/model/storage'], function(amazonStorage) {
     amazonStorage.clearAmazonCheckout();
 });
 <?php endif; ?>

--- a/src/PayV2/view/frontend/templates/config.phtml
+++ b/src/PayV2/view/frontend/templates/config.phtml
@@ -22,5 +22,11 @@ require (['uiRegistry'], function(registry) {
     registry.set('amazonPayV2', <?= /* @noEscape */ \Zend_Json::encode($block->getConfig()); ?>);
 });
 
+<?php if ($block->getRequest()->getFrontName() != 'checkout'): ?>
+require (['jquery', 'Amazon_PayV2/js/model/storage'], function($, amazonStorage) {
+    amazonStorage.clearAmazonCheckout();
+});
+<?php endif; ?>
+
 </script>
 <?php endif ?>

--- a/src/PayV2/view/frontend/web/js/model/storage.js
+++ b/src/PayV2/view/frontend/web/js/model/storage.js
@@ -15,7 +15,8 @@
 
 define([
     'jquery',
-    'Amazon_PayV2/js/model/amazon-payv2-config'
+    'Amazon_PayV2/js/model/amazon-payv2-config',
+    'jquery/jquery-storageapi'
 ], function ($, amazonPayV2Config) {
     'use strict';
 


### PR DESCRIPTION
Temporarily use the checkout session id as a placeholder transaction id since we don't get a chargeId back until after completeCheckout is called. Once checkout is complete, update the transaction id with the chargeId.