### PR TITLE
Alexa Model - use Phrases to construct Exceptions

### DIFF
--- a/Model/Alexa.php
+++ b/Model/Alexa.php
@@ -18,6 +18,7 @@ namespace Amazon\Pay\Model;
 
 use Amazon\Pay\Client\ClientFactoryInterface;
 use Magento\Framework\Module\Dir;
+use Magento\Framework\Phrase;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Store\Model\ScopeInterface;
 
@@ -94,7 +95,7 @@ class Alexa
             $errorMessage = __('API error:') . ' (' . $status . ') ';
             $errorMessage .= !empty($response['reasonCode']) ? $response['reasonCode'] . ': ' : '';
             $errorMessage .= !empty($response['message']) ? $response['message'] : '';
-            throw new \Magento\Framework\Exception\StateException($errorMessage);
+            throw new \Magento\Framework\Exception\StateException(new Phrase($errorMessage));
         }
         return $response;
     }
@@ -115,7 +116,9 @@ class Alexa
         }
         $transaction = $this->transactionRepository->getByTransactionType($transationType, $payment->getId());
         if (!$transaction) {
-            throw new \Magento\Framework\Exception\NotFoundException('Failed to lookup order transaction');
+            throw new \Magento\Framework\Exception\NotFoundException(
+                new Phrase('Failed to lookup order transaction')
+            );
         }
         $response = $this->apiCall($order->getStoreId(), 'getCharge', [$transaction->getTxnId()]);
         return $response['chargePermissionId'];


### PR DESCRIPTION
Fixes # .
Fixes a bug where if an Exception is thrown in the Alexa model, the Exception is not instantiated correctly using a Phrase.

#### Additional details about this PR
Both StateException and NotFoundException extend LocalizedException, which expects a \Magento\Framework\Phrase as a construct param. Instead, both of these were being constructed with a string, resulting in the Exception never being thrown or caught correctly.

Error is written to /var/log/nginx/error.log: "PHP message: PHP Fatal error: Uncaught TypeError: Argument 1 passed to Magento\Framework\Exception\LocalizedException::__construct() must be an instance of Magento\Framework\Phrase, string given..."