### PR TITLE
avoid magento swagger crash

### DIFF
--- a/Api/CheckoutSessionManagementInterface.php
+++ b/Api/CheckoutSessionManagementInterface.php
@@ -21,7 +21,7 @@ namespace Amazon\Pay\Api;
 interface CheckoutSessionManagementInterface
 {
     /**
-     * @param mixed|null $cartId
+     * @param string|null $cartId
      * @return mixed
      */
     public function getConfig($cartId = null);


### PR DESCRIPTION
Hi, magento swagger crashes due to that "mixed" type in $cartId parameter notation. Changing it to "string" fixes the problem.

Fixes #1078 .

#### Additional details about this PR