### PR TITLE
When fallback quote should be load from checkout session

### DIFF
--- a/Helper/Session.php
+++ b/Helper/Session.php
@@ -215,7 +215,7 @@ class Session
     {
         try {
             if (empty($cartId)) {
-                $quote = $this->session->getQuote();
+                $quote = $this->getQuote();
             } else {
                 $quoteId = $this->maskedQuoteIdConverter->execute($cartId);
                 $quote = $this->cartRepository->get($quoteId);


### PR DESCRIPTION
When cartid is null it fall back to load quote from customer session but actually it should be from checkout session because customer session doesn't contain quote.