### PR TITLE
Check if getDefaultStoreView() returned a Store before building IPN URL

### DIFF
--- a/Block/Adminhtml/System/Config/Form/IpnUrl.php
+++ b/Block/Adminhtml/System/Config/Form/IpnUrl.php
@@ -32,10 +32,12 @@ class IpnUrl extends \Magento\Config\Block\System\Config\Form\Field
         $store = $this->_storeManager->getDefaultStoreView();
         $valueReturn = '';
 
-        $baseUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true);
-        if ($baseUrl) {
-            $value       = $baseUrl . 'amazon_pay/payment/ipn/';
-            $valueReturn = "<div>".$this->escapeHtml($value)."</div>";
+        if ($store) {
+            $baseUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true);
+            if ($baseUrl) {
+                $value       = $baseUrl . 'amazon_pay/payment/ipn/';
+                $valueReturn = "<div>".$this->escapeHtml($value)."</div>";
+            }
         }
 
         $html = '<td class="value">';


### PR DESCRIPTION
Fixes #1098 .

As explained in #1098 getDefaultStoreView could return NULL for example when GWS is enabled.

This PR validates the return value before trying to call its methods.