### PR TITLE
fix: Fix visibility of billing address form

### DIFF
--- a/view/frontend/web/template/billing-address.html
+++ b/view/frontend/web/template/billing-address.html
@@ -1,7 +1,9 @@
 <div if="isAddressLoaded" id="amazon-billing-address" class="checkout-billing-address">
     <render args="detailsTemplate"/>
-    <fieldset class="fieldset" data-bind="visible: isAddressFormVisible()">
-        <render args="formTemplate"/>
+    <fieldset class="fieldset" data-bind="visible: !isAddressDetailsVisible()">
+        <div data-bind="fadeVisible: isAddressFormVisible">
+            <render args="formTemplate"/>
+        </div>
         <render args="actionsTemplate"/>
     </fieldset>
 </div>


### PR DESCRIPTION
Fixes visibility of billing address form. 

**Current**
1. Assuming that the address is valid, when payment step is loaded, we can see:
- Address details
- Button to edit address
- Opened address form
- Buttons to update address or cancel editing

**Expected**
1.  Assuming that the address is valid, when payment step is loaded, we can see:
- Address details
- Button to edit address
- You can click the edit button to toggle address form and update/cancel buttons

This MR applies changes that are more in line with [original Magento template](https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Checkout/view/frontend/web/template/billing-address.html) and it fixes the issue above.

#### Additional details about this PR