### PR TITLE
Account for whitespace/newline trimming on responses from

### DIFF
--- a/Test/Mftf-24/Test/AmazonCheckoutSuccessTest.xml
+++ b/Test/Mftf-24/Test/AmazonCheckoutSuccessTest.xml
@@ -27,9 +27,9 @@
 
         <grabTextFrom selector="{{CheckoutSuccessMainSection.orderNumber}}" stepKey="orderNumber" />
         <magentoCLI command="amazon:payment:sales:verify-charge-permission" arguments="--orderId {$orderNumber}" stepKey="command" />
-        <assertEquals stepKey="refIdAssert">
+        <assertStringContainsString stepKey="seeMerchantReferenceIdMatchesOrderNumber">
+            <expectedResult type="string">true</expectedResult>
             <actualResult type="string">${command}</actualResult>
-            <expectedResult type="string">true\n</expectedResult>
-        </assertEquals>
+        </assertStringContainsString>
     </test>
 </tests>


### PR DESCRIPTION
MagentoWebDriver's magentoCLI() function

In the MFTF version (3.9.0) included with Magento 2.4.4, the <magentoCLI> test action was changed to trim the output printed by the corresponding console command. This broke the AmazonCheckoutSuccess test since it was expecting the newline to be included in the returned string.

To accommodate both 2.4.3 and 2.4.4, we can change from an 'equals' to a 'contains' assertion.