### PR TITLE
replace removed logger method

### DIFF
--- a/Logger/ExceptionLogger.php
+++ b/Logger/ExceptionLogger.php
@@ -28,6 +28,6 @@ class ExceptionLogger
     public function logException(\Exception $e)
     {
         $message = (string) $e;
-        $this->logger->addError($message);
+        $this->logger->error($message);
     }
 }


### PR DESCRIPTION
Magento2.4.4 requires Monolog ^2.6.
Since Monolog 2.x,  all the add* methods is removed.
Therefore, as indicated in this PR, we must use error() instead of addError().