### PR TITLE
#1191 use session from usercontext instead of empty one

### DIFF
--- a/Helper/Session.php
+++ b/Helper/Session.php
@@ -238,7 +238,7 @@ class Session
             // we only really want to utilize masked ids here unless retrieved elsewhere
             if (empty($cartId) || is_numeric($cartId)) {
                 $quote = $this->getQuote();
-                if (!$quote) {
+                if (!$quote || !$quote->getId()) {
                     // here we'll check the user context for any available cart data before moving on
                     $userContextCartId = $this->getCartIdViaUserContext();
                     if ($userContextCartId !== null) {


### PR DESCRIPTION
Fixes #1191  .

Added the additional check for quoteId to fetch quote from user context in headless environment instead of returning an empty new quote.