### PR TITLE
Fix setup:upgrade error when using prefixed tables

### DIFF
--- a/Setup/Patch/Data/PerformKeyUpgrade.php
+++ b/Setup/Patch/Data/PerformKeyUpgrade.php
@@ -18,6 +18,7 @@
 namespace Amazon\Pay\Setup\Patch\Data;
 
 use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\App\Config\ConfigResource\ConfigInterface;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
@@ -56,21 +57,29 @@ class PerformKeyUpgrade implements DataPatchInterface
     private $moduleDataSetup;
 
     /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
      * @param KeyUpgradeInterface $keyUpgrade
      * @param ConfigInterface $config
      * @param EncryptorInterface $encryptor
      * @param ModuleDataSetupInterface $moduleDataSetup
+     * @param ResourceConnection $resourceConnection
      */
     public function __construct(
         KeyUpgradeInterface $keyUpgrade,
         ConfigInterface $config,
         EncryptorInterface $encryptor,
-        ModuleDataSetupInterface $moduleDataSetup
+        ModuleDataSetupInterface $moduleDataSetup,
+        ResourceConnection $resourceConnection
     ) {
         $this->keyUpgrade = $keyUpgrade;
         $this->config = $config;
         $this->encryptor = $encryptor;
         $this->moduleDataSetup = $moduleDataSetup;
+        $this->resourceConnection = $resourceConnection;
     }
 
     /**
@@ -125,7 +134,7 @@ class PerformKeyUpgrade implements DataPatchInterface
     {
         $conn = $this->moduleDataSetup->getConnection();
         $select = $conn->select()
-            ->from('core_config_data', ['scope_id', 'scope', 'value'])
+            ->from($this->resourceConnection->getTableName('core_config_data'), ['scope_id', 'scope', 'value'])
             ->where('path = ?', 'payment/amazon_payment/access_key')
             ->order('scope_id');
 
@@ -142,7 +151,7 @@ class PerformKeyUpgrade implements DataPatchInterface
     {
         $conn = $this->moduleDataSetup->getConnection();
         $select = $conn->select()
-            ->from('core_config_data', ['scope_id', 'scope', 'path', 'value'])
+            ->from($this->resourceConnection->getTableName('core_config_data'), ['scope_id', 'scope', 'path', 'value'])
             ->where('path in (?)', array_keys(self::PATH_TRANSLATION_MAP))
             ->order('scope_id');
 


### PR DESCRIPTION
Fixes a fatal error during setup upgrade step, for stores using prefix database tables.
```
[staging] Unable to apply data patch Amazon\Pay\Setup\Patch\Data\PerformKeyUpgrade for module Amazon_Pay. Original exception message: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'client_mage_prod.core_config_data' doesn't exist, query was: SELECT `core_config_data`.`scope_id`, `core_config_data`.`scope`, `core_config_data`.`value` FROM `core_config_data` WHERE (path = 'payment/amazon_payment/access_key') ORDER BY `scope_id` ASC
[staging]  error  in magento2.php on line 295:
[staging] exit code 1 (General error)
done magento:upgrade:db 29s 566ms
ERROR: Task magento:upgrade:db failed!
```