### PR TITLE
ASD-1152

### DIFF
--- a/Model/Resolver/CheckoutSessionDetails.php
+++ b/Model/Resolver/CheckoutSessionDetails.php
@@ -42,6 +42,7 @@ class CheckoutSessionDetails implements ResolverInterface
      * @return array
      * @throws GraphQlInputException
      */
+
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
         $amazonSessionId = $args['amazonSessionId'] ?? false;
@@ -72,7 +73,7 @@ class CheckoutSessionDetails implements ResolverInterface
      * @param mixed $queryType
      * @return mixed
      */
-    private function getQueryTypesData($amazonSessionId, $queryType)
+    protected function getQueryTypesData($amazonSessionId, $queryType)
     {
         $result = false;
         if (in_array($queryType, self::QUERY_TYPES, true)) {

--- a/Model/Resolver/CheckoutSessionDetailsV2.php
+++ b/Model/Resolver/CheckoutSessionDetailsV2.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Amazon\Pay\Model\Resolver;
+
+
+
+use Amazon\Pay\Model\CheckoutSessionManagement;
+use Amazon\Pay\Model\Resolver\CheckoutSessionDetails;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+
+class CheckoutSessionDetailsV2 extends CheckoutSessionDetails implements ResolverInterface
+{
+
+    /**
+     * CheckoutSessionDetails constructor
+     *
+     * @param CheckoutSessionManagement $checkoutSessionManagement
+     */
+    public function __construct(
+        CheckoutSessionManagement $checkoutSessionManagement
+    ) {
+        parent::__construct($checkoutSessionManagement);
+    }
+
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        $amazonSessionId = $args['amazonSessionId'] ?? false;
+        $queryTypes = $args['queryTypes'] ?? false;
+
+        if (!$amazonSessionId) {
+            throw new GraphQlInputException(__('Required parameter "amazonSessionId" is missing'));
+        }
+
+        if (!$queryTypes) {
+            throw new GraphQlInputException(__('Required parameter "queryTypes" is missing'));
+        }
+
+        $response = [];
+        foreach ($queryTypes as $queryType) {
+            $response[$queryType] = $this->getQueryTypesData($amazonSessionId, $queryType) ?:  [];
+        }
+
+        return [
+            'response' => $response
+        ];
+    }
+}

--- a/Model/Resolver/CheckoutSessionDetailsV2.php
+++ b/Model/Resolver/CheckoutSessionDetailsV2.php
@@ -2,12 +2,9 @@
 
 namespace Amazon\Pay\Model\Resolver;
 
-
-
-use Amazon\Pay\Model\CheckoutSessionManagement;
-use Amazon\Pay\Model\Resolver\CheckoutSessionDetails;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 
@@ -15,16 +12,16 @@ class CheckoutSessionDetailsV2 extends CheckoutSessionDetails implements Resolve
 {
 
     /**
-     * CheckoutSessionDetails constructor
+     * Get CheckoutSessionDetails
      *
-     * @param CheckoutSessionManagement $checkoutSessionManagement
+     * @param Field $field
+     * @param ContextInterface $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @return array
+     * @throws GraphQlInputException
      */
-    public function __construct(
-        CheckoutSessionManagement $checkoutSessionManagement
-    ) {
-        parent::__construct($checkoutSessionManagement);
-    }
-
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
         $amazonSessionId = $args['amazonSessionId'] ?? false;
@@ -42,7 +39,7 @@ class CheckoutSessionDetailsV2 extends CheckoutSessionDetails implements Resolve
         foreach ($queryTypes as $queryType) {
             $response[$queryType] = $this->getQueryTypesData($amazonSessionId, $queryType) ?:  [];
 
-            switch($queryType) {
+            switch ($queryType) {
                 case 'shipping':
                 case 'billing':
                     $response[$queryType] = $response[$queryType][0];

--- a/Model/Resolver/CheckoutSessionDetailsV2.php
+++ b/Model/Resolver/CheckoutSessionDetailsV2.php
@@ -52,8 +52,6 @@ class CheckoutSessionDetailsV2 extends CheckoutSessionDetails implements Resolve
             }
         }
 
-        return [
-            'response' => $response
-        ];
+        return $response;
     }
 }

--- a/Model/Resolver/CheckoutSessionDetailsV2.php
+++ b/Model/Resolver/CheckoutSessionDetailsV2.php
@@ -28,7 +28,7 @@ class CheckoutSessionDetailsV2 extends CheckoutSessionDetails implements Resolve
     public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
     {
         $amazonSessionId = $args['amazonSessionId'] ?? false;
-        $queryTypes = $args['queryTypes'] ?? false;
+        $queryTypes = ['shipping','billing','payment'];
 
         if (!$amazonSessionId) {
             throw new GraphQlInputException(__('Required parameter "amazonSessionId" is missing'));
@@ -41,6 +41,15 @@ class CheckoutSessionDetailsV2 extends CheckoutSessionDetails implements Resolve
         $response = [];
         foreach ($queryTypes as $queryType) {
             $response[$queryType] = $this->getQueryTypesData($amazonSessionId, $queryType) ?:  [];
+
+            switch($queryType) {
+                case 'shipping':
+                case 'billing':
+                    $response[$queryType] = $response[$queryType][0];
+                    break;
+                default:
+                    //nothing
+            }
         }
 
         return [

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -5,6 +5,9 @@ type Query {
     checkoutSessionDetails(amazonSessionId: String!, queryTypes: [String!]): CheckoutSessionDetailsOutput
     @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetails")
 
+    checkoutSessionDetailsV2(amazonSessionId: String!, queryTypes: [String!]): CheckoutSessionDetailsOutputV2
+    @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetailsV2")
+
     checkoutSessionSignIn(buyerToken: String!): CheckoutSessionSignInOutput
     @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionSignIn")
 }
@@ -26,6 +29,36 @@ type Mutation {
 
 type CheckoutSessionDetailsOutput {
     response: String!
+}
+
+type CheckoutSessionDetailsOutputV2 {
+    response: CheckoutSessionDetailsResponseOutput
+}
+
+type CheckoutSessionDetailsResponseOutput {
+    shipping: [CheckoutSessionDetailsShippingOutput]
+    billing: [CheckoutSessionDetailsShippingOutput]
+    payment: String
+}
+
+type CheckoutSessionDetailsShippingOutput {
+    city: String
+    firstname: String
+    lastname: String
+    country_id: String
+    street: [String]
+    postcode: String
+    company: String
+    telephone: String
+    region: String
+    region_id: String
+    region_code: String
+    email: String
+}
+
+type AddressOutput {
+    line1: String
+    line2: String
 }
 
 type CheckoutSessionConfigOutput {

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -33,10 +33,6 @@ type CheckoutSessionDetailsOutput {
 }
 
 type CheckoutSessionDetailsOutputV2 {
-    response: CheckoutSessionDetailsResponseOutput
-}
-
-type CheckoutSessionDetailsResponseOutput {
     shipping: CheckoutSessionDetailsShippingOutput
     billing: CheckoutSessionDetailsShippingOutput
     payment: String

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -3,7 +3,7 @@ type Query {
     @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionConfig")
 
     checkoutSessionDetails(amazonSessionId: String!, queryTypes: [String!]): CheckoutSessionDetailsOutput
-    @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetails")
+    @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetails") @deprecated
 
     checkoutSessionDetailsV2(amazonSessionId: String!, queryTypes: [String!]): CheckoutSessionDetailsOutputV2
     @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetailsV2")
@@ -38,7 +38,7 @@ type CheckoutSessionDetailsOutputV2 {
 type CheckoutSessionDetailsResponseOutput {
     shipping: [CheckoutSessionDetailsShippingOutput]
     billing: [CheckoutSessionDetailsShippingOutput]
-    payment: String
+    payment: [String]
 }
 
 type CheckoutSessionDetailsShippingOutput {

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -3,9 +3,10 @@ type Query {
     @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionConfig")
 
     checkoutSessionDetails(amazonSessionId: String!, queryTypes: [String!]): CheckoutSessionDetailsOutput
-    @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetails") @deprecated
+    @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetails")
+    @deprecated(reason: "Use checkoutSessionDetailsV2 for a more conventional GraphQL response format")
 
-    checkoutSessionDetailsV2(amazonSessionId: String!, queryTypes: [String!]): CheckoutSessionDetailsOutputV2
+    checkoutSessionDetailsV2(amazonSessionId: String!): CheckoutSessionDetailsOutputV2
     @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetailsV2")
 
     checkoutSessionSignIn(buyerToken: String!): CheckoutSessionSignInOutput
@@ -36,9 +37,9 @@ type CheckoutSessionDetailsOutputV2 {
 }
 
 type CheckoutSessionDetailsResponseOutput {
-    shipping: [CheckoutSessionDetailsShippingOutput]
-    billing: [CheckoutSessionDetailsShippingOutput]
-    payment: [String]
+    shipping: CheckoutSessionDetailsShippingOutput
+    billing: CheckoutSessionDetailsShippingOutput
+    payment: String
 }
 
 type CheckoutSessionDetailsShippingOutput {
@@ -54,11 +55,6 @@ type CheckoutSessionDetailsShippingOutput {
     region_id: String
     region_code: String
     email: String
-}
-
-type AddressOutput {
-    line1: String
-    line2: String
 }
 
 type CheckoutSessionConfigOutput {


### PR DESCRIPTION
Fixes # 
- Added CheckoutSessionDetailsV2 resolver for GraphQL.
- Original CheckoutSessionDetails GraphQL query set as deprecated.
- Fixed GraphQL schema type.

#### Additional details about this PR
- CheckoutSessionDetailsV2 resolver extends original one, so private methods now  are set as protected to be used on new resolver class. 
