### PR TITLE
[GRAPHQL] query checkoutSessionDetails doesn't adhere to GraphQl best practices

### DIFF
--- a/Model/Resolver/CheckoutSessionDetails.php
+++ b/Model/Resolver/CheckoutSessionDetails.php
@@ -10,6 +10,10 @@ use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 
+/**
+ * @deprecated Replaced by CheckoutSessionDetailsV2
+ * @see CheckoutSessionDetailsV2
+ */
 class CheckoutSessionDetails implements ResolverInterface
 {
 

--- a/Model/Resolver/CheckoutSessionDetailsV2.php
+++ b/Model/Resolver/CheckoutSessionDetailsV2.php
@@ -49,7 +49,7 @@ class CheckoutSessionDetailsV2 implements \Magento\Framework\GraphQl\Query\Resol
             $response[$field] = $result;
         }
 
-        if (empty($response)) {
+        if ($response === []) {
             throw new GraphQlInputException(__('Amazon session not found.'));
         }
 

--- a/Model/Resolver/CheckoutSessionDetailsV2.php
+++ b/Model/Resolver/CheckoutSessionDetailsV2.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Amazon\Pay\Model\Resolver;
+
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Amazon\Pay\Model\CheckoutSessionManagement;
+
+class CheckoutSessionDetailsV2 implements \Magento\Framework\GraphQl\Query\ResolverInterface
+{
+    /**
+     * @var CheckoutSessionManagement
+     */
+    private $checkoutSessionManagement;
+
+    /**
+     * CheckoutSessionDetails constructor
+     *
+     * @param CheckoutSessionManagement $checkoutSessionManagement
+     */
+    public function __construct(
+        CheckoutSessionManagement $checkoutSessionManagement
+    ) {
+        $this->checkoutSessionManagement = $checkoutSessionManagement;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolve(
+        \Magento\Framework\GraphQl\Config\Element\Field $field,
+        $context,
+        \Magento\Framework\GraphQl\Schema\Type\ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        $amazonSessionId = $args['amazonSessionId'] ?? false;
+        if (!$amazonSessionId) {
+            throw new GraphQlInputException(__('Required parameter "amazonSessionId" is missing'));
+        }
+
+        $response = [];
+        $fields = array_keys($info->getFieldSelection());
+        foreach ($fields as $field) {
+            $result = $this->getQueryTypesData($amazonSessionId, $field);
+            if (!$result) {
+                continue;
+            }
+
+            $response[$field] = $result;
+        }
+
+        if (empty($response)) {
+            throw new GraphQlInputException(__('Amazon session not found.'));
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param string $amazonSessionId
+     * @param string $queryType
+     * @return mixed
+     */
+    protected function getQueryTypesData($amazonSessionId, $queryType)
+    {
+        switch ($queryType) {
+            case 'billing':
+                return $this->filterAddress($this->checkoutSessionManagement->getBillingAddress($amazonSessionId)[0] ?? null);
+            case 'payment':
+                return $this->checkoutSessionManagement->getPaymentDescriptor($amazonSessionId);
+            case 'shipping':
+                return $this->filterAddress($this->checkoutSessionManagement->getShippingAddress($amazonSessionId)[0] ?? null);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array|null $address
+     * @return array|null
+     */
+    protected function filterAddress(?array $address): ?array
+    {
+        if (!$address) {
+            return $address;
+        }
+
+        /**
+         * Remove empty street
+         * ie: ['', 'Street2'] => ['Street2']
+         */
+        $street = $address['street'] ?? null;
+        if (is_array($street)) {
+            $address['street'] = array_filter($street);
+        }
+
+        return $address;
+    }
+}

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -4,7 +4,7 @@ type Query {
 
     checkoutSessionDetails(amazonSessionId: String!, queryTypes: [String!]): CheckoutSessionDetailsOutput
     @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetails")
-    @deprecated(reason: "Use amazonPayCheckoutSessionDetailsV2 query.")
+    @deprecated(reason: "Use checkoutSessionDetailsV2 query.")
 
     checkoutSessionDetailsV2(amazonSessionId: String!): CheckoutSessionDetailsOutputV2
     @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetailsV2")

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -4,6 +4,10 @@ type Query {
 
     checkoutSessionDetails(amazonSessionId: String!, queryTypes: [String!]): CheckoutSessionDetailsOutput
     @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetails")
+    @deprecated(reason: "Use amazonPayCheckoutSessionDetailsV2 query.")
+
+    checkoutSessionDetailsV2(amazonSessionId: String!): CheckoutSessionDetailsOutputV2
+    @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionDetailsV2")
 
     checkoutSessionSignIn(buyerToken: String!): CheckoutSessionSignInOutput
     @resolver(class:"Amazon\\Pay\\Model\\Resolver\\CheckoutSessionSignIn")
@@ -72,4 +76,25 @@ type CompleteCheckoutSessionOutput {
 
 type UpdateCheckoutSessionOutput {
     redirectUrl: String
+}
+
+type CheckoutSessionDetailsOutputV2 {
+    billing: AmazonPayCheckoutSessionDetailAddress
+    shipping: AmazonPayCheckoutSessionDetailAddress
+    payment: String
+}
+
+type AmazonPayCheckoutSessionDetailAddress {
+    city: String
+    firstname: String
+    lastname: String
+    country_id: String
+    street: [String]
+    postcode: String
+    company: String
+    telephone: String
+    region: String
+    region_id: Int
+    region_code: String
+    email: String
 }


### PR DESCRIPTION
As proposed in this issue (#1218), the objective of this MR is to improve the query `checkoutSessionDetails` so that it complies with graphQl standards.

- In order not to break the applications with the old query, I made a new query: `checkoutSessionDetailsV2`, 
- The query `checkoutSessionDetails` is deprecated.
- I also add an exception if no Amazon session is found.

```graphql

query CheckoutSessionDetails($amazonSessionId: String!) {
	checkoutSessionDetailsV2(amazonSessionId: $amazonSessionId) {
		payment
		shipping {
			city
			firstname
			lastname
			street
			company
			telephone
			region
			region_id
			region_code
			email
			postcode
		}
		billing {
			city
			firstname
			lastname
			street
			company
			telephone
			region
			region_id
			region_code
			email
		}
	}
}
```

