### PR TITLE
[GRAPHQL] Add payment/amazon_payment/payment_region option in StoreConfig

### DIFF
--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
+        <arguments>
+            <argument name="extendedConfigData" xsi:type="array">
+                <item name="amazon_payment_region" xsi:type="string">payment/amazon_payment/payment_region</item>
+            </argument>
+        </arguments>
+    </type>
+</config>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -73,3 +73,7 @@ type CompleteCheckoutSessionOutput {
 type UpdateCheckoutSessionOutput {
     redirectUrl: String
 }
+
+type StoreConfig {
+    amazon_payment_region: String @doc(description: "Payment Region for js import")
+}


### PR DESCRIPTION
Expose  `payment/amazon_payment/payment_region` option in graphQl.

```graphql
{
    storeConfig {
        amazon_payment_region
    }
}
```
Issue: https://github.com/amzn/amazon-payments-magento-2-plugin/issues/1222