### PR TITLE
[GRAPHQL] Add configurations in StoreConfig

### DIFF
--- a/Model/Resolver/StoreConfig/IsEnabled.php
+++ b/Model/Resolver/StoreConfig/IsEnabled.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Amazon\Pay\Model\Resolver\StoreConfig;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Amazon\Pay\Model\AmazonConfig;
+
+class IsEnabled implements ResolverInterface
+{
+    private AmazonConfig $amazonConfig;
+
+    public function __construct(
+        AmazonConfig $amazonConfig
+    ) {
+        $this->amazonConfig = $amazonConfig;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        return $this->amazonConfig->isEnabled();
+    }
+}

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -21,6 +21,8 @@
         <arguments>
             <argument name="extendedConfigData" xsi:type="array">
                 <item name="amazon_payment_region" xsi:type="string">payment/amazon_payment/payment_region</item>
+                <item name="amazon_payment_minicart_button_is_visible" xsi:type="string">payment/amazon_payment/minicart_button_is_visible</item>
+                <item name="amazon_payment_pwa_pp_button_is_visible" xsi:type="string">payment/amazon_payment/pwa_pp_button_is_visible</item>
             </argument>
         </arguments>
     </type>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -101,4 +101,9 @@ type UpdateCheckoutSessionOutput {
 
 type StoreConfig {
     amazon_payment_region: String @doc(description: "Payment Region for js import")
+    amazon_payment_minicart_button_is_visible: Boolean @doc(description: "True if button is configured to display in minicart")
+    amazon_payment_pwa_pp_button_is_visible: Boolean @doc(description: "True if button is configured to display on PDP")
+    amazon_payment_is_enabled: Boolean
+    @doc(description: "True if AP is enabled and available for customer/store")
+    @resolver(class: "Amazon\\Pay\\Model\\Resolver\\StoreConfig\\IsEnabled")
 }


### PR DESCRIPTION
Add configurations in StoreConfig type : 

- Add `payment/amazon_payment/minicart_button_is_visible` => `amazon_payment_minicart_button_is_visible`
- Add `payment/amazon_payment/pwa_pp_button_is_visible` => `amazon_payment_pwa_pp_button_is_visible`
- Add `amazon_payment_is_enabled` based on `\Amazon\Pay\Model\AmazonConfig::isEnabled()`

fixes #1234 
