### PR TITLE
Update requirejs-config.js (Issue #1240)

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -50,7 +50,6 @@ var config = {
     },
     map: {
         '*': {
-            amazonPayProductAdd: 'Amazon_Pay/js/amazon-product-add',
             amazonPayButton: 'Amazon_Pay/js/amazon-button',
             amazonPayConfig: 'Amazon_Pay/js/model/amazonPayConfig',
             amazonPayLoginButton: 'Amazon_Pay/js/amazon-login-button',


### PR DESCRIPTION
Fixes Amazon_Pay/js/amazon-product-add.js 404 (Not Found)

Fixes #1240 .

#### Additional details about this PR

Removes `amazonPayProductAdd: 'Amazon_Pay/js/amazon-product-add` from `requirejs-config.js`