### PR TITLE
Fix CleanUpIncompleteSessions cron fails

### DIFF
--- a/Cron/CleanUpIncompleteSessions.php
+++ b/Cron/CleanUpIncompleteSessions.php
@@ -119,7 +119,7 @@ class CleanUpIncompleteSessions
         try {
 
             // Check current state of Amazon checkout session
-            $amazonSession = $this->amazonPayAdapter->getCheckoutSession(null, $checkoutSessionId);
+            $amazonSession = $this->amazonPayAdapter->getCheckoutSession($transactionData['store_id'], $checkoutSessionId);
             $state = $amazonSession['statusDetails']['state'] ?? false;
             switch ($state) {
                 case self::SESSION_STATUS_STATE_CANCELED:


### PR DESCRIPTION

The issue occurred when the cron job ran to clean up incomplete transactions for Amazon Pay.

The error occurred at this line: https://github.com/amzn/amazon-payments-magento-2-plugin/blob/5.17.1/Cron/CleanUpIncompleteSessions.php#L122 because a null value was passed to the getCheckoutSession method, which caused the following error:
`report.ERROR: AmazonCleanUpIncompleteSesssions: Unable to process checkoutSessionId: 64b300f8-de9d-4791-b76b-783bb58ece82. Deprecated Functionality: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /app/nsw6rieuyf75o/vendor/amzn/amazon-pay-api-sdk-php/Amazon/Pay/API/Client.php on line 43 [] []`

When the correct store ID is passed to the getCheckoutSession method, the cron job completes without any issues.

Reported issue here: https://github.com/amzn/amazon-payments-magento-2-plugin/issues/1247)](https://github.com/amzn/amazon-payments-magento-2-plugin/issues/1247