### PR TITLE
Add undefined properties to ParadoxLabsSubscriptionManager

### DIFF
--- a/Model/Subscription/ParadoxLabsSubscriptionManager.php
+++ b/Model/Subscription/ParadoxLabsSubscriptionManager.php
@@ -31,6 +31,26 @@ class ParadoxLabsSubscriptionManager implements SubscriptionManagerInterface
     private $searchCriteriaBuilder;
 
     /**
+     * @var \ParadoxLabs\Subscriptions\Model\Service\QuoteManager
+     */
+    public $quoteManager;
+
+    /**
+     * @var \ParadoxLabs\Subscriptions\Model\Service\ItemManager
+     */
+    public $itemManager;
+
+    /**
+     * @var \ParadoxLabs\Subscriptions\Model\SubscriptionRepository
+     */
+    public $subscriptionRepository;
+
+    /**
+     * @var \ParadoxLabs\Subscriptions\Model\Config
+     */
+    public $subscriptionConfig;
+
+    /**
      * ParadoxLabsSubscriptionManager constructor
      *
      * @param \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder


### PR DESCRIPTION
Resolves amzn/amazon-payments-magento-2-plugin#1252

#### Additional details about this PR

As of PHP 8.2 dynamically created properties will throw a Derepecated functionality notice.  Magento's default behavior is to catch all PHP errors and notices, and throw them as exceptions.

Leaving this deprecated functionality in breaks Magento on PHP 8.2