### PR TITLE
[ASD-1227]: Order in status cancelled on Magento2 (ver. 2.4.6-p5)

### DIFF
--- a/Cron/CleanUpIncompleteSessions.php
+++ b/Cron/CleanUpIncompleteSessions.php
@@ -117,7 +117,6 @@ class CleanUpIncompleteSessions
         $this->logger->info(self::LOG_PREFIX . 'Cleaning up checkout session id: ' . $checkoutSessionId);
 
         try {
-
             // Check current state of Amazon checkout session
             $amazonSession = $this->amazonPayAdapter->getCheckoutSession(null, $checkoutSessionId);
             $state = $amazonSession['statusDetails']['state'] ?? false;
@@ -126,7 +125,8 @@ class CleanUpIncompleteSessions
                     $logMessage = 'Checkout session Canceled, cancelling order and closing transaction: ';
                     $logMessage .= $checkoutSessionId;
                     $this->logger->info(self::LOG_PREFIX . $logMessage);
-                    $this->cancelOrder($orderId);
+                    $cancelledMessage = $this->checkoutSessionManagement->getCanceledMessage($amazonSession);
+                    $this->cancelOrder($orderId, $cancelledMessage);
                     $this->transactionHelper->closeTransaction($transactionData['transaction_id']);
                     break;
                 case self::SESSION_STATUS_STATE_OPEN:
@@ -153,12 +153,12 @@ class CleanUpIncompleteSessions
      * @param int $orderId
      * @return void
      */
-    protected function cancelOrder($orderId)
+    protected function cancelOrder($orderId, $reasonMessage = '')
     {
         $order = $this->loadOrder($orderId);
 
         if ($order) {
-            $this->checkoutSessionManagement->cancelOrder($order);
+            $this->checkoutSessionManagement->cancelOrder($order, null, $reasonMessage);
         } else {
             $this->logger->error(self::LOG_PREFIX . 'Order not found for ID: ' . $orderId);
         }


### PR DESCRIPTION
Removed the $history->delete() line to avoid losing old order comments.

Added 'reasonDescription' from Amazon response wherever it is possible (from session object).

@jaybeckr any suggestion on how to test it? I just used fake data to test the amazon_pay_cleanup_sessions cron job, and other lines are added inside a catch block.