### PR TITLE
Update SendEmail.php - Handle getMethod() on null when PaymentMethod not set yet

### DIFF
--- a/Plugin/SendEmail.php
+++ b/Plugin/SendEmail.php
@@ -56,7 +56,7 @@ class SendEmail
      */
     public function afterSetState(Order $subject, Order $result, string $state)
     {
-        if ($subject->getPayment()->getMethod() == Config::CODE) {
+        if ($subject->getPayment()?->getMethod() == Config::CODE) {
             if ($this->scopeConfig->getValue('sales_email/order/enabled')) {
                 $subject->setCanSendNewEmailFlag(false);
 


### PR DESCRIPTION
Fixes #1264 

#### Additional details about this PR
make sure to handle the case that Payment Method is not set and $subject->getPayment() returns null.