### PR TITLE
Release 5.18.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 5.18.4
+* Fixed null values passed to preg_replace causing deprecation warnings on PHP 8.1+
+* Fixed checkout cancel URL to return the full URL when a domain is configured
+* Fixed PHP error when buyer element is missing from Amazon response
+* Fixed reset password email template failing to render the reset link
+* Fixed password generation to include 4 character classes required by Magento password strength validation
+
 ## 5.18.3
 * Added compatibility with Magento 2.4.8/PHP 8.4
 * Fixed cron job error caused by function visibility

--- a/Helper/Address.php
+++ b/Helper/Address.php
@@ -241,6 +241,12 @@ class Address
      */
     protected function fuzzyCompare($a, $b)
     {
-        return strtolower(preg_replace("#[[:punct:]]#", "", $a)) == strtolower(preg_replace("#[[:punct:]]#", "", $b));
+        $a = ($a === null) ? '' : (string)$a;
+        $b = ($b === null) ? '' : (string)$b;
+
+        $a = strtolower(preg_replace("#[[:punct:]]#", "", $a));
+        $b = strtolower(preg_replace("#[[:punct:]]#", "", $b));
+
+        return $a === $b;
     }
 }

--- a/Model/Adapter/AmazonPayAdapter.php
+++ b/Model/Adapter/AmazonPayAdapter.php
@@ -754,6 +754,10 @@ class AmazonPayAdapter
         if (empty($checkoutCancelUrl)) {
             $cancelUrl = $this->getDefaultCancelUrl();
         } else {
+            // If full URL, use as-is
+            if (preg_match('#^https?://#i', $checkoutCancelUrl)) {
+                return $checkoutCancelUrl;
+            }
             $cancelUrl = $this->url->getUrl($checkoutCancelUrl);
         }
 

--- a/Model/CustomerLinkManagement.php
+++ b/Model/CustomerLinkManagement.php
@@ -23,7 +23,6 @@ use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\Data\CustomerInterfaceFactory;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Model\Session;
-use Magento\Framework\Math\Random;
 
 class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementInterface
 {
@@ -53,11 +52,6 @@ class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementIn
     private $accountManagement;
 
     /**
-     * @var Random
-     */
-    private $random;
-
-    /**
      * CustomerLinkManagement constructor
      *
      * @param CustomerLinkRepositoryInterface $customerLinkRepository
@@ -65,7 +59,6 @@ class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementIn
      * @param CustomerInterface               $customerInterface
      * @param CustomerInterfaceFactory        $customerDataFactory
      * @param AccountManagementInterface      $accountManagement
-     * @param Random                          $random
      */
     public function __construct(
         CustomerLinkRepositoryInterface $customerLinkRepository,
@@ -73,14 +66,12 @@ class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementIn
         CustomerInterface $customerInterface,
         CustomerInterfaceFactory $customerDataFactory,
         AccountManagementInterface $accountManagement,
-        Random $random
     ) {
         $this->customerLinkRepository   = $customerLinkRepository;
         $this->customerLinkFactory = $customerLinkFactory;
         $this->customerInterface   = $customerInterface;
         $this->customerDataFactory = $customerDataFactory;
         $this->accountManagement   = $accountManagement;
-        $this->random              = $random;
     }
 
     /**
@@ -102,7 +93,7 @@ class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementIn
         $customerData->setFirstname($sanitizedNames['first_name']);
         $customerData->setLastname($sanitizedNames['last_name']);
         $customerData->setEmail($amazonCustomer->getEmail());
-        $password = $this->random->getRandomString(64);
+        $password = $this->generatePassword();
 
         $customer = $this->accountManagement->createAccount($customerData, $password);
 
@@ -138,5 +129,51 @@ class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementIn
             'first_name' => trim(preg_replace($pattern, '', htmlspecialchars_decode($customer->getFirstname()))),
             'last_name'  => trim(preg_replace($pattern, '', htmlspecialchars_decode($customer->getLastname())))
         ];
+    }
+
+    /**
+     * Generate a password that satisfies Magento's 4 character-class strength check:
+     * lower, upper, digits, special.
+     *
+     * @param int $length
+     * @return string
+     */
+    private function generatePassword($length = 64)
+    {
+        $lower   = 'abcdefghijklmnopqrstuvwxyz';
+        $upper   = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        $digits  = '0123456789';
+        // Common specials; avoid whitespace and quotes to reduce edge-case issues
+        $special = '!@#$%^&*()-_=+[]{};:,.?~';
+
+        // Ensure at least one from each class
+        $chars = [
+            $this->randChar($lower),
+            $this->randChar($upper),
+            $this->randChar($digits),
+            $this->randChar($special),
+        ];
+
+        $all = $lower . $upper . $digits . $special;
+
+        // Fill the rest
+        for ($i = count($chars); $i < $length; $i++) {
+            $chars[] = $this->randChar($all);
+        }
+
+        // Shuffle to avoid predictable positions
+        shuffle($chars);
+
+        return implode('', $chars);
+    }
+
+    /**
+     * @param string $pool
+     * @return string
+     */
+    private function randChar($pool)
+    {
+        $max = strlen($pool) - 1;
+        return $pool[random_int(0, $max)];
     }
 }

--- a/Model/CustomerLinkManagement.php
+++ b/Model/CustomerLinkManagement.php
@@ -23,6 +23,7 @@ use Magento\Customer\Api\AccountManagementInterface;
 use Magento\Customer\Api\Data\CustomerInterfaceFactory;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Model\Session;
+use Magento\Framework\Math\Random;
 
 class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementInterface
 {
@@ -52,6 +53,11 @@ class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementIn
     private $accountManagement;
 
     /**
+     * @var Random
+     */
+    private $random;
+
+    /**
      * CustomerLinkManagement constructor
      *
      * @param CustomerLinkRepositoryInterface $customerLinkRepository
@@ -59,6 +65,7 @@ class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementIn
      * @param CustomerInterface               $customerInterface
      * @param CustomerInterfaceFactory        $customerDataFactory
      * @param AccountManagementInterface      $accountManagement
+     * @param Random                          $random
      */
     public function __construct(
         CustomerLinkRepositoryInterface $customerLinkRepository,
@@ -66,12 +73,14 @@ class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementIn
         CustomerInterface $customerInterface,
         CustomerInterfaceFactory $customerDataFactory,
         AccountManagementInterface $accountManagement,
+        Random $random
     ) {
         $this->customerLinkRepository   = $customerLinkRepository;
         $this->customerLinkFactory = $customerLinkFactory;
         $this->customerInterface   = $customerInterface;
         $this->customerDataFactory = $customerDataFactory;
         $this->accountManagement   = $accountManagement;
+        $this->random              = $random;
     }
 
     /**
@@ -143,37 +152,24 @@ class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementIn
         $lower   = 'abcdefghijklmnopqrstuvwxyz';
         $upper   = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
         $digits  = '0123456789';
-        // Common specials; avoid whitespace and quotes to reduce edge-case issues
         $special = '!@#$%^&*()-_=+[]{};:,.?~';
 
-        // Ensure at least one from each class
-        $chars = [
-            $this->randChar($lower),
-            $this->randChar($upper),
-            $this->randChar($digits),
-            $this->randChar($special),
-        ];
+        $sets = [$lower, $upper, $digits, $special];
 
-        $all = $lower . $upper . $digits . $special;
-
-        // Fill the rest
-        for ($i = count($chars); $i < $length; $i++) {
-            $chars[] = $this->randChar($all);
+        $password = '';
+        foreach ($sets as $set) {
+            $password .= $this->random->getRandomString(1, $set);
         }
 
-        // Shuffle to avoid predictable positions
+        $all = implode('', $sets);
+        $remaining = max(0, $length - strlen($password));
+        if ($remaining > 0) {
+            $password .= $this->random->getRandomString($remaining, $all);
+        }
+
+        $chars = str_split($password);
         shuffle($chars);
 
         return implode('', $chars);
-    }
-
-    /**
-     * @param string $pool
-     * @return string
-     */
-    private function randChar($pool)
-    {
-        $max = strlen($pool) - 1;
-        return $pool[random_int(0, $max)];
     }
 }

--- a/Model/CustomerLinkManagement.php
+++ b/Model/CustomerLinkManagement.php
@@ -27,6 +27,8 @@ use Magento\Framework\Math\Random;
 
 class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementInterface
 {
+    private const CHARS_SPECIAL = '!@#$%^&*()-_=+[]{};:,.?~';
+
     /**
      * @var CustomerLinkRepositoryInterface
      */
@@ -149,12 +151,12 @@ class CustomerLinkManagement implements \Amazon\Pay\Api\CustomerLinkManagementIn
      */
     private function generatePassword($length = 64)
     {
-        $lower   = 'abcdefghijklmnopqrstuvwxyz';
-        $upper   = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-        $digits  = '0123456789';
-        $special = '!@#$%^&*()-_=+[]{};:,.?~';
-
-        $sets = [$lower, $upper, $digits, $special];
+        $sets = [
+            Random::CHARS_LOWERS,
+            Random::CHARS_UPPERS,
+            Random::CHARS_DIGITS,
+            self::CHARS_SPECIAL
+        ];
 
         $password = '';
         foreach ($sets as $set) {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following table provides an overview on which Git branch is compatible to wh
 Magento Version | Github Branch | Latest release
 ---|---|---
 2.2.6 - 2.2.11 (EOL) | [V2checkout-1.2.x](https://github.com/amzn/amazon-payments-magento-2-plugin/tree/V2checkout-1.2.x)  | 1.20.0 (EOL)
-2.3.0 - 2.4.x | [master](https://github.com/amzn/amazon-payments-magento-2-plugin/tree/master) | 5.18.3
+2.3.0 - 2.4.x | [master](https://github.com/amzn/amazon-payments-magento-2-plugin/tree/master) | 5.18.4
 
 ## Release Notes
 See [CHANGELOG.md](/CHANGELOG.md) 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "amzn/amazon-pay-magento-2-module",
   "description": "Official Magento2 Plugin to integrate with Amazon Pay",
   "type": "magento2-module",
-  "version": "5.18.3",
+  "version": "5.18.4",
   "license": [
     "Apache-2.0"
   ],

--- a/view/frontend/templates/widget/resetpassword.phtml
+++ b/view/frontend/templates/widget/resetpassword.phtml
@@ -19,7 +19,6 @@ use Magento\Framework\Escaper;
     <p>
         <?= $escaper->escapeHtml(__('If you created this account using Amazon Pay,
         you might not know your site password.')) ?><br>
-        <?= $escaper->escapeHtml(__('In order to reset your password, please <a href="%1">Sign Out</a>
-        and click on “Forgot Your Password?” from the Sign In page', $block->getLink())) ?>
+        <?= $escaper->escapeHtml(__('In order to reset your password, please <a href="%1">Sign Out</a> and click on “Forgot Your Password?” from the Sign In page', $escaper->escapeUrl($block->getLink())), ['a']) ?>
     </p>
 </div>


### PR DESCRIPTION
## 5.18.4
* Fixed null values passed to preg_replace causing deprecation warnings on PHP 8.1+
* Fixed checkout cancel URL to return the full URL when a domain is configured
* Fixed PHP error when buyer element is missing from Amazon response
* Fixed reset password email template failing to render the reset link
* Fixed password generation to include 4 character classes required by Magento password strength validation