### PR TITLE
Suppress order confirmation email on order and invoice cancellation

### DIFF
--- a/Plugin/SendEmail.php
+++ b/Plugin/SendEmail.php
@@ -65,6 +65,16 @@ class SendEmail
                     !empty($subject->getStatusHistories()) &&
                     !$subject->getEmailSent()
                     ) {
+                    foreach ($subject->getAllItems() as $item) {
+                        if ($item->getQtyCanceled() > 0) {
+                            return $result;
+                        }
+                    }
+                    if ($subject->hasInvoices() &&
+                        !((float)$subject->getTotalPaid() > 0) &&
+                        !((float)$subject->getTotalInvoiced() > 0)) {
+                        return $result;
+                    }
                     $subject->setCanSendNewEmailFlag(true);
                     $this->orderSender->send($subject);
                 }


### PR DESCRIPTION
Fixes #1259

## Problem

`Plugin\SendEmail::afterSetState()` sends the order confirmation email whenever the order state becomes `STATE_PROCESSING` with `email_sent` not yet set. However, Magento sets a *transient* `STATE_PROCESSING` in two cancellation code paths, so customers of declined/abandoned Amazon Pay orders receive an order confirmation email at the moment the merchant cancels the order or its pending invoice:

1. **Order cancel** — inside `Magento\Sales\Model\Order::registerCancellation()`, items are cancelled before `setState()` runs, and a transient `STATE_PROCESSING` is set when items have qty to refund. The plugin fires on that intermediate state and sends the email.

2. **Invoice cancel** — inside `Magento\Sales\Model\Order\Invoice::cancel()`, cancelling a pending (never captured) invoice resets the order to `STATE_PROCESSING` before the order itself is cancelled. This is the typical admin flow for cleaning up `payment_review` orders whose async payment was declined: cancel the pending invoice first, then cancel the order — and the email goes out on the invoice cancel.

## Fix

Two guards before sending:

- `$item->getQtyCanceled() > 0` on any item → we are inside `registerCancellation()`, skip.
- `$subject->hasInvoices() && !((float)$subject->getTotalPaid() > 0)` → the order has invoices but nothing was ever paid; this is the transient state of `Invoice::cancel()` on a pending invoice, not a completed payment, skip.

Both legitimate flows are unaffected:

| Flow | Result |
|---|---|
| Async approval, capture mode | `Invoice::pay()` increments order `total_paid` *before* the state changes to processing → email sent ✓ |
| Async approval, authorize-only | no invoices on the order → email sent ✓ |
| Cancel pending invoice of a declined order | invoices exist, `total_paid` = 0 → suppressed ✓ |
| Cancel order | item `qty_canceled` > 0 → suppressed ✓ |

## Steps to reproduce (invoice-cancel case)

1. Place an order with Amazon Pay where the async payment is declined (order stays in `payment_review` with a pending invoice).
2. In admin, open the pending invoice and cancel it.
3. Without this fix the customer receives the order confirmation email at that moment (verified in postfix logs on Magento 2.4.7-p8 / module 5.18.4).